### PR TITLE
OAuth configuration support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,22 @@ The main files to be aware of are:
   (logging configuration, sample data file locations, and so forth) that are local to your development
   setup, rather than being common characteristics of everybody's local development environments.
 
+### Customizable Configuration Elements
+
+Several custom sections can be added to the application properties:
+
+* `sample-data` contains configuration for loading fake data into your development environment
+* `web-customization` customizes the server configuration
+    * `cors-origins` is a list of allowed origins for cross-origin resource sharing
+    * `users` is a list of test users (for use in development environments), for testing with various
+    authorization levels
+* `oauth-user-config` customizes the way that OAuth2/OIDC user ID tokens are translated into local
+  users (with local permissions).
+    * `name-path` (optionally) provides a path to the value in the user's `attributes` map where we can find
+    the actual durable user ID (if the IDP's notion of durable user ID does not map to the application's).
+    * `authority-paths` (optionally in some sense, but likely necessarily) configures how to translate the
+    user's `attributes` to internal authorities for this application.
+
 ## Loading Sample Data
 Unless you want to create all the data by hand using the `resources` API (not recommended),
 you will want to configure the application to load some sample data. This is most easily done

--- a/src/main/java/gov/usds/case_issues/authorization/NamedOAuth2User.java
+++ b/src/main/java/gov/usds/case_issues/authorization/NamedOAuth2User.java
@@ -1,0 +1,50 @@
+package gov.usds.case_issues.authorization;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+/**
+ * A simple {@link OAuth2User} implementation that receives its name from outside,
+ * rather than looking it up in the attributes with a simple key.
+ * It should probably extend DefaultOAuth2User or borrow more of the internal structure
+ * from that class, to make equality/hashing work reliably.
+ */
+public class NamedOAuth2User implements OAuth2User {
+
+	@SuppressWarnings("unused")
+	private static final long serialVersionUID = 1L;
+
+	private String name;
+	private Collection<? extends GrantedAuthority> authorities;
+	private Map<String, Object> attributes;
+
+	public NamedOAuth2User(String name, OAuth2User wrapped) {
+		this(name, wrapped.getAuthorities(), wrapped.getAttributes());
+	}
+
+	public NamedOAuth2User(String name,
+			Collection<? extends GrantedAuthority> authorities,
+			Map<String, Object> attributes) {
+		this.name = name;
+		this.authorities = authorities;
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+}

--- a/src/main/java/gov/usds/case_issues/config/DemoUserLoginConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/DemoUserLoginConfig.java
@@ -30,23 +30,18 @@ public class DemoUserLoginConfig {
 
 	@Bean
 	@Order(-1)
-	@SuppressWarnings("checkstyle:IllegalCatch")
 	public WebSecurityPlugin addDemoLogins() {
 		final String apiTitle = _apiInfo.getTitle();
 
 		return http -> {
 			LOG.info("Configuring form login and basic auth on {} with realm {}.", http, apiTitle);
-			try {
-				http
-					.formLogin()
-						.defaultSuccessUrl("/user")
-						.and()
-					.httpBasic()
-						.realmName(apiTitle)
-				;
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
+			http
+				.formLogin()
+					.defaultSuccessUrl("/user")
+					.and()
+				.httpBasic()
+					.realmName(apiTitle)
+			;
 		};
 	}
 

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -1,0 +1,182 @@
+package gov.usds.case_issues.config;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.stereotype.Component;
+
+import gov.usds.case_issues.authorization.CaseIssuePermission;
+import gov.usds.case_issues.authorization.NamedOAuth2User;
+
+@Configuration
+public class OAuthMappingConfig {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OAuthMappingConfig.class);
+
+	@Autowired
+	private OAuth2CustomizationProperties mappedConfig;
+	@Autowired(required=false) //  this is a sneaky way of making the bean conditional: being less sneaky would be better
+	private OAuth2ClientProperties clientConfig;
+
+	@Bean
+	public WebSecurityPlugin oauthConfigurer() {
+		LOG.info("Preparing custom OAuth2 user service configuration");
+		if (clientConfig == null || clientConfig.getRegistration().isEmpty()) {
+			return null; // see above "sneaky" remark
+		}
+		final GrantedAuthoritiesMapper mapper = oauthAuthorityMapper();
+		final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+		final List<String> namePath = Collections.unmodifiableList(
+				new ArrayList<>(mappedConfig.getNamePath()));
+
+		final OAuth2UserService<OAuth2UserRequest, OAuth2User> userService = namePath.isEmpty()
+				? null
+				: r -> {
+					OAuth2User wrapped = delegate.loadUser(r);
+					Optional<String> nameAttr = descend(wrapped.getAttributes(), namePath)
+							.filter(v -> v instanceof String)
+							.map(String.class::cast)
+							;
+					if (nameAttr.isPresent()) {
+						return new NamedOAuth2User(nameAttr.get(), wrapped);
+					} else {
+						return null;
+					}
+				}
+		;
+		return http -> {
+			LOG.info("Configuring OAuth user info service");
+			try {
+				OAuth2LoginConfigurer<HttpSecurity> oauth2Login = http.oauth2Login();
+				if (userService != null) {
+					oauth2Login.userInfoEndpoint().userService(userService);
+				} else {
+					LOG.info("No custom username mapping provided: using fallback service");
+				}
+				if (mapper != null) {
+					oauth2Login.userInfoEndpoint().userAuthoritiesMapper(mapper);
+				}
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+	private GrantedAuthoritiesMapper oauthAuthorityMapper() {
+		LOG.info("Building authority mapper from {}", mappedConfig.authorityPaths);
+		// this is a shallow copy, so it's not as isolated as it should be
+		final List<AuthorityPath> authorityPaths = new ArrayList<>(mappedConfig.authorityPaths);
+		if (authorityPaths.isEmpty()) {
+			LOG.error("No authority mapping configuration found");
+			return null;
+		}
+		return authorities -> {
+			List<GrantedAuthority> translated = new ArrayList<>();
+			LOG.debug("Mapping authorities from {}", authorities);
+			for (GrantedAuthority g : authorities) {
+				LOG.debug("Input authority is {} (type {})", g, g.getClass());
+				if (g instanceof OAuth2UserAuthority) {
+					Map<String, Object> attributes = ((OAuth2UserAuthority) g).getAttributes();
+					LOG.debug("Attributes to check: {}", attributes);
+					for (AuthorityPath p : authorityPaths) {
+						LOG.debug("Examining path {}", p.path);
+						Optional<?> pathResult = descend(attributes, p.path);
+						if (pathResult.isPresent()) {
+							translated.add(p.getAuthority());
+						}
+					}
+				}
+			}
+			return translated;
+		};
+	}
+
+	@Component
+	@ConfigurationProperties(prefix="oauth-user-config", ignoreUnknownFields=false)
+	public static class OAuth2CustomizationProperties {
+		public List<String> namePath = new ArrayList<>();
+		public List<AuthorityPath> authorityPaths = new ArrayList<>();
+
+		public List<String> getNamePath() {
+			return namePath;
+		}
+
+		public void setNamePath(List<String> path) {
+			namePath = path;
+		}
+
+		public List<AuthorityPath> getAuthorityPaths() {
+			return authorityPaths;
+		}
+
+		public void setAuthorityPaths(List<AuthorityPath> authorityPaths) {
+			this.authorityPaths = authorityPaths;
+		}
+
+	}
+
+	public static class AuthorityPath {
+		private CaseIssuePermission authority;
+		private List<String> path;
+
+		public CaseIssuePermission getAuthority() {
+			return authority;
+		}
+		public void setAuthority(CaseIssuePermission name) {
+			this.authority = name;
+		}
+		public List<String> getPath() {
+			return path;
+		}
+		public void setPath(List<String> path) {
+			this.path = path;
+		}
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private static Optional<?> descend(Object o, List<String> path) {
+		Object curr = o;
+		for (String pathElement : path) {
+			LOG.debug("Looking for {} in {}", pathElement, curr);
+			if (curr instanceof Map) {
+				Map<String, Object> cast = Map.class.cast(curr);
+				curr = cast.get(pathElement);
+			}
+			else if (curr instanceof Collection) {
+				return ((Collection<String>) curr).stream().filter(pathElement::equals).findFirst();
+			}
+			else if (curr instanceof String) {
+				return pathElement.equals(curr) ? Optional.of((String) curr) : Optional.empty();
+			}
+		}
+		LOG.debug("Finished path traversal with {}", curr);
+		if (curr instanceof Collection && ((Collection) curr).size() == 1) {
+			Iterator<String> it = ((Iterable) curr).iterator();
+			return it.hasNext() ? Optional.of(it.next()) : Optional.empty();
+		} else {
+			return Optional.ofNullable(curr);
+		}
+	}
+
+}

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -52,18 +52,14 @@ public class OAuthMappingConfig {
 				createDelegatingUserService(new DefaultOAuth2UserService(), mappedConfig.getNamePath());
 		return http -> {
 			LOG.info("Configuring OAuth user info service");
-			try {
-				OAuth2LoginConfigurer<HttpSecurity> oauth2Login = http.oauth2Login();
-				if (userService != null) {
-					oauth2Login.userInfoEndpoint().userService(userService);
-				} else {
-					LOG.info("No custom username mapping provided: using fallback service");
-				}
-				if (mapper != null) {
-					oauth2Login.userInfoEndpoint().userAuthoritiesMapper(mapper);
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
+			OAuth2LoginConfigurer<HttpSecurity> oauth2Login = http.oauth2Login();
+			if (userService != null) {
+				oauth2Login.userInfoEndpoint().userService(userService);
+			} else {
+				LOG.info("No custom username mapping provided: using fallback service");
+			}
+			if (mapper != null) {
+				oauth2Login.userInfoEndpoint().userAuthoritiesMapper(mapper);
 			}
 		};
 	}

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -79,7 +79,10 @@ public class OAuthMappingConfig {
 			if (nameAttr.isPresent()) {
 				return new NamedOAuth2User(nameAttr.get(), wrapped);
 			} else {
-				return null;
+				// AuthenticationException or AccessDeniedException might be better, but probably still
+				// produce an infinite redirect loop
+				throw new IllegalArgumentException("User " + wrapped.getName() +
+					" did not have the expected name attributes");
 			}
 		}
 		;

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -31,6 +31,23 @@ import org.springframework.stereotype.Component;
 import gov.usds.case_issues.authorization.CaseIssuePermission;
 import gov.usds.case_issues.authorization.NamedOAuth2User;
 
+/**
+ * Configuration to customize our integration with an external OAuth2/OIDC identity provider.
+ * If no OAuth2 client is registered with Spring Security, this configuration will do nothing;
+ * if a client is registered, it will configure OAuth2 login, and check for configuration
+ * properties (see {@link OAuth2CustomizationProperties} to see if it should do either of two
+ * other things:
+ * <ol>
+ * <li>If <code>oauth-user-config.name-path</code> is set, it will do a recursive descent through
+ * the user attributes in the OAuth user object to find a new value for the username attribute to
+ * be returned by {@link OAuth2User#getName()} (for cases when the default value is not actually
+ * the durable ID for the user).
+ * <li>If <code>oauth-user-config.authority-paths</code> is set (which it almost certainly should
+ * be), it configure a {@link GrantedAuthoritiesMapper} that will do a similar recursive descent
+ * for each path provided, and if the expected value is found, add the associated
+ * {@link CaseIssuePermission} to the user's authorities.
+ * </ol>
+ */
 @Configuration
 public class OAuthMappingConfig {
 

--- a/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
@@ -38,8 +38,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		// these could be plugins, but they work already
 		configureResourceUrls(http);
 		configureSwaggerUi(http);
-		_configPlugins.forEach(p->p.accept(http));
-
+		for (WebSecurityPlugin p : _configPlugins) {
+			p.apply(http);
+		}
 		http
 			.cors()
 				.and()

--- a/src/main/java/gov/usds/case_issues/config/WebSecurityPlugin.java
+++ b/src/main/java/gov/usds/case_issues/config/WebSecurityPlugin.java
@@ -1,9 +1,15 @@
 package gov.usds.case_issues.config;
 
-import java.util.function.Consumer;
-
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
-public interface WebSecurityPlugin extends Consumer<HttpSecurity> {
+/**
+ * An interface that is like Consumer, but is not composable (because I don't need it to be),
+ * and is declared to throw an exception (because that seems strictly better than converting all the
+ * underlying Exceptions to RuntimeExceptions).
+ */
+@FunctionalInterface
+public interface WebSecurityPlugin {
+
+	void apply(HttpSecurity t) throws Exception;
 
 }

--- a/src/main/java/gov/usds/case_issues/controllers/UserDetailsApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/UserDetailsApiController.java
@@ -14,7 +14,7 @@ import springfox.documentation.annotations.ApiIgnore;
  */
 @RestController
 @RequestMapping("/user")
-@Profile("dev")
+@Profile("auth-testing")
 @ApiIgnore
 public class UserDetailsApiController {
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,6 +2,7 @@ spring:
   profiles:
     include:
     - local
+    - auth-testing
 logging:
   level:
       # NOTE: add any of the below in application-local.yml to turn on something interesting

--- a/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
+++ b/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
@@ -1,0 +1,199 @@
+package gov.usds.case_issues.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+import gov.usds.case_issues.authorization.CaseIssuePermission;
+
+public class OAuthMappingConfigTest {
+
+	private static final List<String> NEVER_FOUND = Arrays.asList("no_such_attribute","nopenopenope");
+
+	@Test
+	public void oauthAuthorityMapper_emptyInput_nullMapper() {
+		assertNull(OAuthMappingConfig.oauthAuthorityMapper(null));
+		assertNull(OAuthMappingConfig.oauthAuthorityMapper(Collections.emptyList()));
+	}
+
+	@Test
+	public void oauthAuthorityMapper_noAttributes_noAuthorities() {
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(
+			Collections.singletonList(new OAuthMappingConfig.AuthorityPath(CaseIssuePermission.READ_CASES, NEVER_FOUND)));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> inputAuthorities= Collections.singleton(
+				new OAuth2UserAuthority(Collections.singletonMap("my_user_key", "my_user_value"))
+		);
+		assertEquals(0, mapper.mapAuthorities(inputAuthorities).size());
+	}
+
+	@Test
+	public void oauthAuthorityMapper_emptyPath_authorityFound() {
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(
+			Collections.singletonList(new OAuthMappingConfig.AuthorityPath(CaseIssuePermission.READ_CASES, Collections.emptyList())));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> inputAuthorities= Collections.singleton(
+				new OAuth2UserAuthority(Collections.singletonMap("my_user_key", "my_user_value"))
+		);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(inputAuthorities);
+		assertEquals(1, mapped.size());
+		assertTrue(mapped.contains(CaseIssuePermission.READ_CASES));
+	}
+
+	@Test
+	public void oauthAuthorityMapper_pathToNull_authorityNotFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("no_such_key"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(0, mapped.size());
+	}
+
+	@Test
+	public void oauthAuthorityMapper_pathToMap_authorityFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(1, mapped.size());
+		assertTrue(mapped.contains(CaseIssuePermission.READ_CASES));
+	}
+
+	@Test
+	public void oauthAuthorityMapper_pathToValidScalar_authorityFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr", "scalar_name", "name_in_scalar"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(1, mapped.size());
+		assertTrue(mapped.contains(CaseIssuePermission.READ_CASES));
+	}
+
+	@Test
+	public void oauthAuthorityMapper_pathToInvalidScalar_authorityNotFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr", "scalar_name", "NOT CORRECT"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(0, mapped.size());
+	}
+
+	@Test
+	public void oauthAuthorityMapper_pathToValidListElement_authorityFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr", "name_list", "actual_name"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(1, mapped.size());
+		assertTrue(mapped.contains(CaseIssuePermission.READ_CASES));
+	}
+	@Test
+	public void oauthAuthorityMapper_pathToInvalidListElement_authorityNotFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr", "name_list", "NOT ACTUAL NAME"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(0, mapped.size());
+	}
+
+	@org.junit.Ignore // I am not sure what the correct behavior should be here
+	@Test
+	public void oauthAuthorityMapper_pathToEmptyList_authorityNotFound() {
+		OAuthMappingConfig.AuthorityPath path = new OAuthMappingConfig.AuthorityPath(
+				CaseIssuePermission.READ_CASES, Arrays.asList("my_attr", "empty_list"));
+		GrantedAuthoritiesMapper mapper = OAuthMappingConfig.oauthAuthorityMapper(Collections.singletonList(path));
+		assertNotNull(mapper);
+		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(simpleAuthority());
+		assertEquals(0, mapped.size());
+	}
+
+	@Test
+	public void createDelegatingUserService_emptyInput_nullService() {
+		assertNull(OAuthMappingConfig.createDelegatingUserService(null, null));
+		assertNull(OAuthMappingConfig.createDelegatingUserService(null, Collections.emptyList()));
+	}
+
+	@Test
+	public void createDelegatingUserService_nameInList_correctUser() {
+		Map<String, Object> attr = simpleAttributes();
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "name_list");
+		OAuth2User user = service.loadUser(null); // we ignore the input anyway
+		assertEquals("actual_name", user.getName());
+		assertEquals(attr, user.getAttributes());
+		assertEquals(Collections.singleton(new SimpleGrantedAuthority("respect")), user.getAuthorities());
+	}
+
+	@Test
+	public void createDelegatingUserService_nameInScalar_correctUser() {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "scalar_name");
+		OAuth2User user = service.loadUser(null);
+		assertEquals("name_in_scalar", user.getName());
+		assertEquals(simpleAttributes(), user.getAttributes());
+		assertEquals(Collections.singleton(new SimpleGrantedAuthority("respect")), user.getAuthorities());
+	}
+
+	@Test
+	public void createDelegatingUserService_pathToNull_noUser() {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "nopenopenope");
+		assertNull(service.loadUser(null));
+	}
+
+	@Test
+	public void createDelegatingUserService_pathToMap_noUser() {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr");
+		assertNull(service.loadUser(null));
+	}
+
+	@Test
+	public void createDelegatingUserService_pathToEmptyList_noUser() {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "empty_list");
+		assertNull(service.loadUser(null));
+	}
+
+	private OAuth2UserService<OAuth2UserRequest, OAuth2User> setupService(String... namePath) {
+		return OAuthMappingConfig.createDelegatingUserService(
+			r->new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority("respect")), simpleAttributes(), "name"),
+			Arrays.asList(namePath)
+		);
+	}
+	private Set<OAuth2UserAuthority> simpleAuthority() {
+		return Collections.singleton(new OAuth2UserAuthority(simpleAttributes()));
+	}
+
+	private Map<String, Object> simpleAttributes() {
+		Map<String, Object> attr = new HashMap<>();
+		attr.put("name", "not actually the name");
+		Map<String, Object> myAttr = new HashMap<>();
+		myAttr.put("name_list", Arrays.asList("actual_name"));
+		myAttr.put("empty_list", Collections.emptyList());
+		myAttr.put("scalar_name", "name_in_scalar");
+		attr.put("my_attr", myAttr);
+		return attr;
+	}
+}

--- a/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
+++ b/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
@@ -158,22 +158,19 @@ public class OAuthMappingConfigTest {
 		assertEquals(Collections.singleton(new SimpleGrantedAuthority("respect")), user.getAuthorities());
 	}
 
-	@Test
-	public void createDelegatingUserService_pathToNull_noUser() {
-		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "nopenopenope");
-		assertNull(service.loadUser(null));
+	@Test(expected=IllegalArgumentException.class)
+	public void createDelegatingUserService_pathToNull_error() {
+		setupService("my_attr", "nopenopenope").loadUser(null);
 	}
 
-	@Test
-	public void createDelegatingUserService_pathToMap_noUser() {
-		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr");
-		assertNull(service.loadUser(null));
+	@Test(expected=IllegalArgumentException.class)
+	public void createDelegatingUserService_pathToMap_error() {
+		setupService("my_attr").loadUser(null);
 	}
 
-	@Test
-	public void createDelegatingUserService_pathToEmptyList_noUser() {
-		OAuth2UserService<OAuth2UserRequest, OAuth2User> service = setupService("my_attr", "empty_list");
-		assertNull(service.loadUser(null));
+	@Test(expected=IllegalArgumentException.class)
+	public void createDelegatingUserService_pathToEmptyList_error() {
+		setupService("my_attr", "empty_list").loadUser(null);
 	}
 
 	private OAuth2UserService<OAuth2UserRequest, OAuth2User> setupService(String... namePath) {


### PR DESCRIPTION
Support for configuring OAuth2/OIDC SSO:

* map attributes on the OAuth2 user to authorities in this system, using a fairly flexible configuration
* find the actual durable user ID if it is not where it is supposed to be
* tests for some of the above code
* refactoring to eliminate a bad behavior that checkstyle was correctly flagging and we had been just squashing the warnings on.