### PR TITLE
Postgresql and Liquibase support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv"
 
 	implementation "com.vladmihalcea:hibernate-types-52:2.5.0"
+	implementation "org.liquibase:liquibase-core"
 
 	runtimeOnly 'org.hsqldb:hsqldb'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -60,6 +60,7 @@ org.jboss.logging:jboss-logging:3.3.2.Final
 org.jboss:jandex:2.0.5.Final
 org.json:json:20180130
 org.latencyutils:LatencyUtils:2.0.3
+org.liquibase:liquibase-core:3.6.3
 org.mapstruct:mapstruct:1.2.0.Final
 org.ow2.asm:asm:5.0.4
 org.slf4j:jul-to-slf4j:1.7.26
@@ -106,3 +107,4 @@ org.springframework:spring-orm:5.1.9.RELEASE
 org.springframework:spring-tx:5.1.9.RELEASE
 org.springframework:spring-web:5.1.9.RELEASE
 org.springframework:spring-webmvc:5.1.9.RELEASE
+org.yaml:snakeyaml:1.23

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +50,7 @@ import gov.usds.case_issues.authorization.NamedOAuth2User;
  * </ol>
  */
 @Configuration
+@ConditionalOnWebApplication
 public class OAuthMappingConfig {
 
 	private static final Logger LOG = LoggerFactory.getLogger(OAuthMappingConfig.class);

--- a/src/main/java/gov/usds/case_issues/config/RestConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/RestConfig.java
@@ -1,5 +1,6 @@
 package gov.usds.case_issues.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
@@ -13,6 +14,7 @@ import gov.usds.case_issues.db.repositories.NoteSubtypeRepository;
 import gov.usds.case_issues.db.repositories.TaggedEntityRepository;
 
 @Configuration
+@ConditionalOnWebApplication
 public class RestConfig implements RepositoryRestConfigurer {
 
 	@Override

--- a/src/main/java/gov/usds/case_issues/config/SampleDataConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SampleDataConfig.java
@@ -5,14 +5,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import gov.usds.case_issues.db.model.NoteType;
 
 @ConfigurationProperties(prefix="sample-data", ignoreUnknownFields=false)
-@Configuration
-@Profile({"dev","test"})
+@Component
+@Lazy
+@Profile({"dev"})
 public class SampleDataConfig {
 
 	private List<SampleDataFileSpec> files = new ArrayList<>();

--- a/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -20,6 +21,7 @@ import gov.usds.case_issues.authorization.CaseIssuePermission;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled=false, prePostEnabled=true)
 @Configuration
+@ConditionalOnWebApplication
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SecurityConfig.class);

--- a/src/main/java/gov/usds/case_issues/config/SwaggerConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -28,6 +29,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 @Configuration
 @PropertySource(ignoreResourceNotFound=true,value="api.properties")
+@ConditionalOnWebApplication
 public class SwaggerConfig {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerConfig.class);

--- a/src/main/java/gov/usds/case_issues/config/WebConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/WebConfig.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.filter.OrderedFilter;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * Configuration that customizes Spring MVC for our specific needs.
  */
 @Configuration
+@ConditionalOnWebApplication
 public class WebConfig implements WebMvcConfigurer {
 
 	private static final Logger LOG = LoggerFactory.getLogger(WebConfig.class);

--- a/src/main/java/gov/usds/case_issues/config/WebConfigurationProperties.java
+++ b/src/main/java/gov/usds/case_issues/config/WebConfigurationProperties.java
@@ -5,11 +5,13 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import gov.usds.case_issues.authorization.CaseIssuePermission;
 
 @Component
+@Lazy
 @ConfigurationProperties(prefix="web-customization", ignoreUnknownFields=false)
 public class WebConfigurationProperties {
 

--- a/src/main/java/gov/usds/case_issues/db/model/CaseNote.java
+++ b/src/main/java/gov/usds/case_issues/db/model/CaseNote.java
@@ -2,12 +2,15 @@ package gov.usds.case_issues.db.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.ManyToOne;
 
 @Entity
 public class CaseNote extends WriteOnceEntity {
 
 	@Column(nullable=false)
+	@Enumerated(EnumType.STRING)
 	private NoteType noteType;
 	@ManyToOne(optional=true)
 	private NoteSubtype noteSubtype;

--- a/src/main/java/gov/usds/case_issues/db/model/NoteAssociation.java
+++ b/src/main/java/gov/usds/case_issues/db/model/NoteAssociation.java
@@ -1,6 +1,7 @@
 package gov.usds.case_issues.db.model;
 
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import org.hibernate.annotations.NaturalId;
@@ -10,9 +11,11 @@ public class NoteAssociation extends UpdatableEntity {
 
 	@NaturalId
 	@ManyToOne(optional=false)
+	@JoinColumn(nullable=false)
 	private CaseSnooze snooze;
 	@NaturalId
 	@ManyToOne(optional=false)
+	@JoinColumn(nullable=false)
 	private CaseNote note;
 
 	private NoteAssociation() { /* for hibernate */}

--- a/src/main/java/gov/usds/case_issues/db/model/NoteSubtype.java
+++ b/src/main/java/gov/usds/case_issues/db/model/NoteSubtype.java
@@ -1,10 +1,13 @@
 package gov.usds.case_issues.db.model;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Entity
 public class NoteSubtype extends TaggedEntity {
 
+	@Enumerated(EnumType.STRING)
 	private NoteType forNoteType;
 	private String urlTemplate;
 

--- a/src/main/java/gov/usds/case_issues/db/model/NoteSubtype.java
+++ b/src/main/java/gov/usds/case_issues/db/model/NoteSubtype.java
@@ -1,12 +1,16 @@
 package gov.usds.case_issues.db.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.validation.constraints.NotNull;
 
 @Entity
 public class NoteSubtype extends TaggedEntity {
 
+	@NotNull
+	@Column(nullable=false)
 	@Enumerated(EnumType.STRING)
 	private NoteType forNoteType;
 	private String urlTemplate;

--- a/src/main/java/gov/usds/case_issues/db/model/TaggedEntity.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TaggedEntity.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public abstract class TaggedEntity extends UpdatableEntity {
 
 	@NaturalId
+	@NotNull
 	@Column(nullable=false)
 	@JsonProperty("tag")
 	@Pattern(regexp="[-\\w]+")

--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -39,34 +39,34 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 @NamedNativeQueries({
 	@NamedNativeQuery(
 		name = "snoozed",
-		query = "SELECT * from ( "+ TroubleCase.CASE_DTO_QUERY + ") "
+		query = "SELECT * from " + TroubleCase.CASE_DTO_CTE
 			  + "WHERE last_snooze_end >= CURRENT_TIMESTAMP "
 			  + "ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC",
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
 		name = "unSnoozed",
-		query = "SELECT * from ( "+ TroubleCase.CASE_DTO_QUERY + ") "
+		query = "SELECT * from " + TroubleCase.CASE_DTO_CTE
 			  + "WHERE last_snooze_end is null or last_snooze_end < CURRENT_TIMESTAMP "
 			  + "ORDER BY case_creation ASC, internal_id ASC",
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
 		name = "snoozed.count",
-		query = "SELECT count(1) as entity_count from ( "+ TroubleCase.CASE_DTO_QUERY + ") "
+		query = "SELECT count(1) as entity_count from " + TroubleCase.CASE_DTO_CTE
 			  + "WHERE last_snooze_end >= CURRENT_TIMESTAMP ",
 		resultSetMapping = "rowCount"
 	),
 	@NamedNativeQuery(
 		name = "unSnoozed.count",
-		query = "SELECT count(1) as entity_count from ( "+ TroubleCase.CASE_DTO_QUERY + ") "
+		query = "SELECT count(1) as entity_count from " + TroubleCase.CASE_DTO_CTE
 			  + "WHERE last_snooze_end is null or last_snooze_end < CURRENT_TIMESTAMP ",
 		resultSetMapping = "rowCount"
 	),
 	@NamedNativeQuery(
 		name = "summary",
 		query = "SELECT " + TroubleCase.CASE_SNOOZE_DECODE + " as snooze_state, count(1) "
-				+ "FROM ( " + TroubleCase.CASE_DTO_QUERY + ") "
+				+ "FROM " + TroubleCase.CASE_DTO_CTE
 				+ "GROUP BY " + TroubleCase.CASE_SNOOZE_DECODE
 	),
 })
@@ -99,6 +99,7 @@ public class TroubleCase extends UpdatableEntity {
 			+ "where c.internal_id=openissues1_.issue_case_internal_id "
 			+ "and ( openissues1_.issue_closed is null)"
 		+ ")";
+	public static final String CASE_DTO_CTE = "(" + CASE_DTO_QUERY + ") as trouble_case_dto ";
 
 	@NaturalId
 	@ManyToOne(optional=false)

--- a/src/main/java/gov/usds/case_issues/db/model/UpdatableEntity.java
+++ b/src/main/java/gov/usds/case_issues/db/model/UpdatableEntity.java
@@ -11,7 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
  * A normal, editable entity, which can be updated one or more times after being created.
  */
 @MappedSuperclass
-public class UpdatableEntity extends WriteOnceEntity {
+public abstract class UpdatableEntity extends WriteOnceEntity {
 
 	@LastModifiedBy
 	private String updatedBy;

--- a/src/main/java/gov/usds/case_issues/db/model/WriteOnceEntity.java
+++ b/src/main/java/gov/usds/case_issues/db/model/WriteOnceEntity.java
@@ -4,8 +4,10 @@ import java.util.Date;
 
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.SequenceGenerator;
 
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -21,8 +23,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class WriteOnceEntity {
 
+	public static final String DEFAULT_SEQUENCE_GENERATOR = "caseIssueDefaultSequence";
+
 	@Id
-	@GeneratedValue
+	@GeneratedValue(
+		strategy=GenerationType.SEQUENCE,
+		generator=DEFAULT_SEQUENCE_GENERATOR
+	)
+	@SequenceGenerator(
+		name=DEFAULT_SEQUENCE_GENERATOR,
+		sequenceName="case_issue_entity_id_sequence"
+	)
 	@JsonIgnore
 	private Long internalId;
 

--- a/src/main/resources/application-autotest.yml
+++ b/src/main/resources/application-autotest.yml
@@ -11,6 +11,9 @@ spring:
       hibernate:
         format_sql: true
         generate_statistics: false # way too noisy to be worth it
+    hibernate.ddl-auto: none
+  liquibase:
+    enabled: true
 bind-testing:
   web-conf-a:
     cors-origins:

--- a/src/main/resources/application-db-migrate.yml
+++ b/src/main/resources/application-db-migrate.yml
@@ -1,0 +1,11 @@
+spring:
+  main:
+    web-application-type: NONE
+  liquibase:
+    enabled: true
+    default-schema: public
+    liquibase-schema: public
+  jpa.hibernate.ddl-auto: validate
+logging:
+  level:
+    org.hibernate.SQL: DEBUG

--- a/src/main/resources/application-db-postgresql.yml
+++ b/src/main/resources/application-db-postgresql.yml
@@ -3,3 +3,4 @@ spring:
     url: jdbc:postgresql://localhost/case_issues
   jpa:
     database: POSTGRESQL
+    hibernate.ddl-auto: validate

--- a/src/main/resources/application-db-postgresql.yml
+++ b/src/main/resources/application-db-postgresql.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost/case_issues
+  jpa:
+    database: POSTGRESQL

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spring:
       hibernate:
         format_sql: false
         generate_statistics: true # possibly too verbose, but useful to have around
+  liquibase:
+    enabled: false
 logback:
   access:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,11 @@ spring:
     rest:
       basePath: /resources
   jpa:
+    database: HSQL
     # we do not want Hibernate to start making DB calls during Jackson rendering: much better to have that
     # throw an exception so we know we have to update the persistence configuration.
     open-in-view: false
+    hibernate.ddl-auto: create
     properties:
       hibernate:
         format_sql: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,294 @@
+x-ref-data:
+   type-defs:
+      - &idtype bigint
+      - &string varchar(255)
+      - &user_date datetime # a date that may come from outside, which may include time zone information that we may want to preserve
+   column-defs:
+      - column: &pk_column
+          name: internal_id
+          type: *idtype
+          remarks: The internal database identifier for this entity.
+          constraints:
+            primaryKey: true
+            nullable: false
+      - column: &created_at_column
+          name: created_at
+          type: DATETIME
+          remarks: The creation timestamp for this entity.
+          constraints:
+            nullable: false
+      - column: &created_by_column
+          name: created_by
+          type: *string
+          remarks: The ID of the user who created this entity.
+          constraints:
+            nullable: true
+      - column: &updated_at_column
+          name: updated_at
+          type: DATETIME
+          remarks: The timestamp for the most recent update of this entity.
+          constraints:
+            nullable: false
+      - column: &updated_by_column
+          name: updated_by
+          type: *string
+          remarks: The ID of the user who most recently updated this entity.
+          constraints:
+            nullable: true
+      - column: &tag_column
+          name: external_id
+          type: *string
+          remarks: The external ID (or "tag") used by the API to identify this entity (URL-safe string).
+          constraints:
+            unique: true
+            nullable: false
+      - column: &name_column
+          name: name
+          type: *string
+          remarks: The human-readable name of this entity (may contain spaces and punctuation).
+          constraints:
+            nullable: false
+      - column: &description_column
+          name: description
+          type: *string
+          remarks: A longer (optional) plain-language description of this entity, for use in wider list views.
+
+databaseChangeLog:
+  - changeSet:
+      id: initial-schema
+      author: ben.warfield@usds.dhs.gov
+      comment: The database schema required for the initial pilot deployment of the Case Issue API.
+      changes:
+        - createSequence:
+            sequenceName: case_issue_entity_id_sequence
+            startValue: 1
+        - createTable:
+            tableName: case_management_system
+            remarks: Case Management Systems that are known to this application (each case belongs to exactly one case management system).
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *tag_column
+              - column: *name_column
+              - column: *description_column
+              - column:
+                  name: application_url
+                  type: *string
+                  remarks: The root URL for the best available web view of this case management system.
+              - column:
+                  name: case_details_url_template
+                  type: *string
+                  remarks: A URL template for generating direct hyperlinks to cases in this case management system.
+        - createTable:
+            tableName: case_type
+            remarks: Types of case that this application distinguishes between (each case can have only one type).
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *tag_column
+              - column: *name_column
+              - column: *description_column
+        - createTable:
+            tableName: trouble_case
+            remarks: A case that has been entered into this application as having some issue that needs to be tracked (therefore by definition a trouble case of some kind).
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column:
+                  name: case_management_system_internal_id
+                  remarks: The case management system where this case is being tracked outside of this application.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__trouble_case__case_management_system
+                    references: case_management_system
+              - column:
+                  name: receipt_number
+                  type: *string
+                  remarks: The unique identifier for a case, as understood by the case management system that owns it.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: case_creation
+                  type: *user_date
+                  remarks: The date and time when this case was originally created (e.g. the form or letter was received). Immutable.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: case_type_internal_id
+                  remarks: What type of case this is (e.g. what form or what category of letter or inquiry). Immutable.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__trouble_case__case_type
+                    references: case_type
+              - column:
+                  name: extra_data
+                  type: varchar(32000)
+                  remarks: Additional data about this case, as of the time it was most recently updated in this application. Mutable.
+        - addUniqueConstraint:
+            tableName: trouble_case
+            constraint_name: uk__trouble_case
+            columnNames: case_management_system_internal_id, receipt_number
+        - createTable:
+            tableName: case_issue
+            remarks: An issue (e.g. "assigned to an invalid queue") that exists for some period of time with a specific case.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column:
+                  name: issue_case_internal_id
+                  type: *idtype
+                  remarks: The case that this issue is about.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__case_issue__trouble_case
+                    references: trouble_case
+              - column:
+                  name: issue_type
+                  type: *string
+                  remarks: The type of this issue, as a URL-safe string (e.g. "AGING").
+              - column:
+                  name: issue_created
+                  type: *user_date
+                  remarks: The date this issue was first seen (likely but not necessarily the same as created_at).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: issue_closed
+                  type: *user_date
+                  remarks: The date this issue was closed out.
+                  constraints:
+                    nullable: true
+        - addUniqueConstraint:
+            tableName: case_issue
+            constraint_name: uk__case_issue
+            columnNames: issue_case_internal_id, issue_type, issue_created
+        - createTable:
+            tableName: case_snooze
+            remarks: An instance of a particular case being "snoozed" for a period of time.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column:
+                  name: snooze_case_internal_id
+                  type: *idtype
+                  remarks: The case that was snoozed.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__case_snooze__trouble_case
+                    references: trouble_case
+              - column:
+                  name: snooze_reason
+                  type: *string
+                  remarks: The reason (as a URL-safe string) for snoozing this case (e.g. "TICKET_OPENED"). Immutable.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: snooze_start
+                  type: *user_date
+                  remarks: The date and time when the case was snoozed. Immutable.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: snooze_end
+                  type: *user_date
+                  remarks: The date and time when the snooze ended or will end.
+                  constraints:
+                    nullable: false
+        - createTable:
+            tableName: note_subtype
+            remarks: A category of note (applying to one specific note type)
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *tag_column
+              - column: *name_column
+              - column: *description_column
+              - column:
+                  name: for_note_type
+                  type: *string
+                  remarks: Which type of note this subtype is applicable for.
+                  constraints:
+                    nullable: false
+                    # check constraint would be appropriate but cannot be added inline,
+                    # and postgresql has an Enum type anyway
+              - column:
+                  name: url_template
+                  type: *string
+                  remarks: The URL template for generating a link to notes with this subtype (for notes that are actually external tickets or the like).
+        - createTable:
+            tableName: case_note
+            remarks: A note, annotation, or other attachment to a case (generally by way of a case_snooze). Immutable so as to be reusable.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column:
+                  name: note_type
+                  type: *string
+                  remarks: The type of note or annotation.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: note_subtype_internal_id
+                  type: *idtype
+                  remarks: The subtype (if applicable) for this annotation.
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__case_note__note_subtype
+                    references: note_subtype
+              - column:
+                  name: content
+                  remarks: The content of this note or annotation.
+                  type: *string
+                  constraints:
+                    nullable: false
+                    unique: true
+        - createTable:
+            tableName: note_association
+            remarks: The association between a note and snoozed case (by way of the snooze object).
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column:
+                  name: snooze_internal_id
+                  type: *idtype
+                  remarks: The active case snooze for the annotated case when this association was created.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__note_association__case_snooze
+                    references: case_snooze
+              - column:
+                  name: note_internal_id
+                  type: *idtype
+                  remarks: The annotation content to associate to a case.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__note_association__case_note
+                    references: case_note
+        - addUniqueConstraint:
+            tableName: note_association
+            constraint_name: uk__note_association
+            columnNames: snooze_internal_id, note_internal_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,7 +2,7 @@ x-ref-data:
    type-defs:
       - &idtype bigint
       - &string varchar(255)
-      - &user_date datetime # a date that may come from outside, which may include time zone information that we may want to preserve
+      - &user_date timestamp with time zone # a date that may come from outside, which may include time zone information that we may want to preserve
    column-defs:
       - column: &pk_column
           name: internal_id
@@ -62,6 +62,7 @@ databaseChangeLog:
         - createSequence:
             sequenceName: case_issue_entity_id_sequence
             startValue: 1
+            incrementBy: 50
         - createTable:
             tableName: case_management_system
             remarks: Case Management Systems that are known to this application (each case belongs to exactly one case management system).

--- a/src/main/resources/hibernate.properties
+++ b/src/main/resources/hibernate.properties
@@ -1,7 +1,2 @@
-hibernate.connection.driver_class=org.hsqldb.jdbc.JDBCDriver
-hibernate.connection.url=jdbc:hsqldb:mem:case-issue-db
-# this is where it gets fun
-hibernate.hbm2ddl.auto=create
 hibernate.show_sql=false
-hibernate.dialect=org.hibernate.dialect.HSQLDialect
 hibernate.types.print.banner=false

--- a/src/test/java/gov/usds/case_issues/db/repositories/CaseManagementSystemRepositoryTest.java
+++ b/src/test/java/gov/usds/case_issues/db/repositories/CaseManagementSystemRepositoryTest.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
-import gov.usds.case_issues.test_util.DbTruncator;
 
 public class CaseManagementSystemRepositoryTest extends CaseIssueApiTestBase {
 
@@ -26,12 +25,10 @@ public class CaseManagementSystemRepositoryTest extends CaseIssueApiTestBase {
 
 	@Autowired
 	private CaseManagementSystemRepository repo;
-	@Autowired
-	private DbTruncator truncator;
 
 	@Before
 	public void emptyDb() {
-		truncator.truncateAll();
+		truncateDb();
 	}
 
 	@Test

--- a/src/test/java/gov/usds/case_issues/db/repositories/CaseManagementSystemRepositoryTest.java
+++ b/src/test/java/gov/usds/case_issues/db/repositories/CaseManagementSystemRepositoryTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
-import gov.usds.case_issues.test_util.HsqlDbTruncator;
+import gov.usds.case_issues.test_util.DbTruncator;
 
 public class CaseManagementSystemRepositoryTest extends CaseIssueApiTestBase {
 
@@ -27,7 +27,7 @@ public class CaseManagementSystemRepositoryTest extends CaseIssueApiTestBase {
 	@Autowired
 	private CaseManagementSystemRepository repo;
 	@Autowired
-	private HsqlDbTruncator truncator;
+	private DbTruncator truncator;
 
 	@Before
 	public void emptyDb() {

--- a/src/test/java/gov/usds/case_issues/db/repositories/TroubleCaseRepositoryTest.java
+++ b/src/test/java/gov/usds/case_issues/db/repositories/TroubleCaseRepositoryTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.validation.ConstraintViolationException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,8 @@ import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
 public class TroubleCaseRepositoryTest extends CaseIssueApiTestBase {
 
 	private static final int GIANT_LIST_SIZE = 100_000;
+	private static final int LARGE_LIST_SIZE = 29_999;
+
 
 	@Autowired
 	private TroubleCaseRepository _repo;
@@ -56,6 +60,16 @@ public class TroubleCaseRepositoryTest extends CaseIssueApiTestBase {
 
 	@Test
 	public void getAllByCaseManagementSystemAndReceiptNumberIn_longRequestList_dbOK() {
+		CaseManagementSystem m1 = _dataService.ensureCaseManagementSystemInitialized("M1", "System 1", null);
+		List<String> receipts = new ArrayList<>(LARGE_LIST_SIZE);
+		for (int i = 0; i < LARGE_LIST_SIZE; i++) {
+			receipts.add(String.format("FFFF%07d", i));
+		}
+		_repo.getAllByCaseManagementSystemAndReceiptNumberIn(m1, receipts);
+	}
+
+	@Test(expected=ConstraintViolationException.class)
+	public void getAllByCaseManagementSystemAndReceiptNumberIn_excessiveRequestList_validationError() {
 		CaseManagementSystem m1 = _dataService.ensureCaseManagementSystemInitialized("M1", "System 1", null);
 		List<String> receipts = new ArrayList<>(GIANT_LIST_SIZE);
 		for (int i = 0; i < GIANT_LIST_SIZE; i++) {

--- a/src/test/java/gov/usds/case_issues/services/CsvLoaderTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CsvLoaderTest.java
@@ -29,8 +29,8 @@ import gov.usds.case_issues.db.model.TroubleCase;
 import gov.usds.case_issues.db.model.projections.CaseIssueSummary;
 import gov.usds.case_issues.db.repositories.CaseIssueRepository;
 import gov.usds.case_issues.db.repositories.TroubleCaseRepository;
+import gov.usds.case_issues.test_util.DbTruncator;
 import gov.usds.case_issues.test_util.FixtureDataInitializationService;
-import gov.usds.case_issues.test_util.HsqlDbTruncator;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -38,7 +38,7 @@ import gov.usds.case_issues.test_util.HsqlDbTruncator;
 public class CsvLoaderTest {
 
 	@Autowired
-	private HsqlDbTruncator truncator;
+	private DbTruncator truncator;
 	@Autowired
 	private FixtureDataInitializationService dataService;
 	@Autowired

--- a/src/test/java/gov/usds/case_issues/services/SampleDataServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/SampleDataServiceTest.java
@@ -17,6 +17,7 @@ import gov.usds.case_issues.config.SampleDataConfig.NoteSubtypeDefinition;
 import gov.usds.case_issues.config.SampleDataConfig.TaggedResource;
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.NoteType;
 import gov.usds.case_issues.db.repositories.CaseIssueRepository;
 import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
 import gov.usds.case_issues.db.repositories.CaseSnoozeRepository;
@@ -82,6 +83,7 @@ public class SampleDataServiceTest extends CaseIssueApiTestBase {
 		noteDefiniton.setTag("tag");
 		noteDefiniton.setName("name");
 		noteDefiniton.setDescription("description");
+		noteDefiniton.setNoteType(NoteType.TAG);
 		loaderConfig.setNoteSubtypes(Arrays.asList(noteDefiniton));
 		_service.saveNoteTypes(loaderConfig);
 		assertEquals(_subtypeRepository.count(), 1);

--- a/src/test/java/gov/usds/case_issues/test_util/CaseIssueApiTestBase.java
+++ b/src/test/java/gov/usds/case_issues/test_util/CaseIssueApiTestBase.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public abstract class CaseIssueApiTestBase {
 
 	@Autowired
-	private HsqlDbTruncator _truncator;
+	private DbTruncator _truncator;
 	@Autowired
 	protected FixtureDataInitializationService _dataService;
 

--- a/src/test/java/gov/usds/case_issues/test_util/DbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/DbTruncator.java
@@ -1,0 +1,9 @@
+package gov.usds.case_issues.test_util;
+
+import javax.transaction.Transactional;
+
+public interface DbTruncator {
+
+	void truncateAll();
+
+}

--- a/src/test/java/gov/usds/case_issues/test_util/DbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/DbTruncator.java
@@ -1,7 +1,5 @@
 package gov.usds.case_issues.test_util;
 
-import javax.transaction.Transactional;
-
 public interface DbTruncator {
 
 	void truncateAll();

--- a/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
@@ -1,5 +1,8 @@
 package gov.usds.case_issues.test_util;
 
+import java.util.Arrays;
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.slf4j.Logger;
@@ -13,12 +16,25 @@ public class HsqlDbTruncator implements DbTruncator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HsqlDbTruncator.class);
 
+	private final List<String> allTables = Arrays.asList(
+		"case_management_system",
+		"case_type",
+		"trouble_case",
+		"case_issue",
+		"case_snooze",
+		"note_subtype",
+		"case_note",
+		"note_association"
+	);
+
 	@Autowired
 	private JdbcTemplate jdbc;
 
 	@Transactional
 	public void truncateAll() {
 		LOG.warn("Attempting to truncate all tables.");
-		jdbc.execute("TRUNCATE SCHEMA PUBLIC AND COMMIT NO CHECK");
+		for (String tableName : allTables) {
+			jdbc.execute("TRUNCATE TABLE " + tableName + " AND COMMIT NO CHECK");
+		}
 	}
 }

--- a/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
@@ -9,7 +9,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-public class HsqlDbTruncator {
+public class HsqlDbTruncator implements DbTruncator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HsqlDbTruncator.class);
 

--- a/src/test/java/gov/usds/case_issues/test_util/PgDbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/PgDbTruncator.java
@@ -1,0 +1,45 @@
+package gov.usds.case_issues.test_util;
+
+import javax.transaction.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("db-postgresql")
+@Primary
+public class PgDbTruncator implements DbTruncator {
+
+	/** Credit: https://stackoverflow.com/questions/2829158/truncating-all-tables-in-a-postgres-database */
+	private static final String TRUNCATE_FUNCTION = "DO " +
+			"$func$ " +
+			"BEGIN " +
+			"   EXECUTE " +
+			"   (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE' " +
+			"    FROM   pg_class " +
+			"    WHERE  relkind = 'r' " + // only tables
+			"    AND    relnamespace = 'public'::regnamespace " + // probably should be property-driven
+			"   ); " +
+			"END " +
+			"$func$;";
+
+	private static final Logger LOG = LoggerFactory.getLogger(PgDbTruncator.class);
+
+	@Autowired
+	private JdbcTemplate jdbc;
+
+	/* (non-Javadoc)
+	 * @see gov.usds.case_issues.test_util.DbTruncator#truncateAll()
+	 */
+	@Override
+	@Transactional
+	public void truncateAll() {
+		LOG.warn("Attempting to truncate all tables.");
+		jdbc.execute(TRUNCATE_FUNCTION);
+	}
+}

--- a/src/test/java/gov/usds/case_issues/test_util/PgDbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/PgDbTruncator.java
@@ -23,6 +23,7 @@ public class PgDbTruncator implements DbTruncator {
 			"   (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE' " +
 			"    FROM   pg_class " +
 			"    WHERE  relkind = 'r' " + // only tables
+			"    AND oid::regclass::text not like 'databasechangelog%' " + // no liquibase tables!
 			"    AND    relnamespace = 'public'::regnamespace " + // probably should be property-driven
 			"   ); " +
 			"END " +


### PR DESCRIPTION
Support for controlling the schema using Liquibase, and running with either postgresql or hsqldb as the back end (for now, at least).

Notable aspects:
* giant YAML changelog file
* a bunch of minor tweaks to entities because there are some column-types and constraints we were less careful about before than we are now
* using the magic of profiles and externalized properties to turn the entire web app into a command-line application instead of a web server