### PR TITLE
Made native queries support non-default schemas.

### DIFF
--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -89,13 +89,13 @@ public class TroubleCase extends UpdatableEntity {
 		+ "else 'CURRENTLY_SNOOZED' end";
 	public static final String CASE_DTO_QUERY =
 		"SELECT c.*, "
-		+ "(SELECT MAX(snooze_end) FROM case_snooze s where s.snooze_case_internal_id = c.internal_id) last_snooze_end "
-		+ "FROM trouble_case c "
+		+ "(SELECT MAX(snooze_end) FROM {h-schema}case_snooze s where s.snooze_case_internal_id = c.internal_id) last_snooze_end "
+		+ "FROM {h-schema}trouble_case c "
 		+ "WHERE case_management_system_internal_id = :caseManagementSystemId "
 		+ "AND case_type_internal_id = :caseTypeId "
 		+ "AND exists ("
 			+ "select openissues1_.internal_id "
-			+ "from case_issue openissues1_ "
+			+ "from {h-schema}case_issue openissues1_ "
 			+ "where c.internal_id=openissues1_.issue_case_internal_id "
 			+ "and ( openissues1_.issue_closed is null)"
 		+ ")";

--- a/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
+++ b/src/test/java/gov/usds/case_issues/test_util/HsqlDbTruncator.java
@@ -8,6 +8,7 @@ import javax.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,8 @@ public class HsqlDbTruncator implements DbTruncator {
 	private static final Logger LOG = LoggerFactory.getLogger(HsqlDbTruncator.class);
 
 	private List<String> allTables;
+	@Value("${spring.jpa.properties.hibernate.default_schema:public}")
+	private String hibernateSchema;
 
 	@Autowired
 	private JdbcTemplate jdbc;
@@ -31,7 +34,7 @@ public class HsqlDbTruncator implements DbTruncator {
 		LOG.warn("Attempting to truncate all tables.");
 		String sql = TABLE_QUERY;
 		if (allTables == null) {
-			allTables = jdbc.queryForList(sql, "PUBLIC").stream()
+			allTables = jdbc.queryForList(sql, hibernateSchema.toUpperCase()).stream()
 					.map(m->(String) m.get("TABLE_NAME"))
 					.collect(Collectors.toList());
 			LOG.info("Initialized HSQLDB table list: {}", allTables);


### PR DESCRIPTION
Made all the NamedNativeQuery entries in TroubleCase, as well as the database truncators (theoretically, in the HSQLDB case), handle being in a schema other than "public".