### PR TITLE
CSRF protection for API endpoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ You can run unit tests as a group using `./gradlew test`, or run all checks usin
 
 To configure your IDE to report style violations, use the checkstyle configuration in [config/checkstyle/checkstyle.xml].
 
-## Running the Application
+## Starting the Application
 
 1. Using the command line
 
@@ -105,6 +105,10 @@ Then refer to that format in the upload using the `uploadSchema` request paramet
 2. Update the lock file with `./gradlew dependencies --write-locks`
 3. Rebuild the project with `./gradlew build`
 
+# Running the Application Locally
+
+Once you have started your local server, this information will help you get started experimenting with it.
+
 ## Exploring the API
 
 The API is divided into two distinct sections: one under the `resources` tree, which is
@@ -114,3 +118,28 @@ intended for administrative and testing purposes, and the main customer-facing A
 The `resources` API uses the HAL browser, which can be found at http://localhost:8080/resources.
 
 The main API has an OpenAPI specification, and can be viewed at http://localhost:8080/swagger-ui.html.
+
+## Authentication and Authorization
+
+By default (unless you override this in `application-local.yml`) there are three users available
+when the `dev` profile is activated: `admin`, `boring_user` and `service`. All of them have their
+username as their password, and can be used either through the default form-based login page
+(at `/login`) or with HTTP Basic Authentication (e.g. `curl -u admin:admin ...`). Their permissions are:
+
+* `admin`: all `/resource` operations, and all `/api` operations except for the PUT endpoint that
+  updates the issue list.
+* `boring_user`: all `/api` operations except for the PUT endpoint that updates the issue list.
+* `service`: _only_ the PUT endpoint that updates the issue list.
+
+All unsafe operations require a CSRF token tied to the user's current session. (Arguably, this
+makes HTTP Basic Authentication somewhat useless even in the development environment—patches
+are welcome!)
+
+To obtain the CSRF token for your current session, you should send a GET to `/csrf`, which will return
+the token and the acceptable ways of submitting it on unsafe requests (a header and a form parameter,
+of which only the header is likely useful in this context).
+
+The CSRF token will be automatically read and used by the Swagger UI at `/swagger-ui.html`, but not by
+the HAL browser at `/resources`. However, the HAL browser has an entry field for "Custom Request Headers"
+at the  top of the screen: simply paste your desired CSRF header (probably something along the lines
+of `X-CSRF-TOKEN: abcd-ef01234-567890`) into that text area before making an unsafe request.

--- a/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 
 import gov.usds.case_issues.authorization.CaseIssuePermission;
 import gov.usds.case_issues.authorization.CustomAccessDeniedHandler;
@@ -55,7 +54,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 					.authenticated()
 				.and()
 			.csrf()
-				.ignoringRequestMatchers(AnyRequestMatcher.INSTANCE)
 				.and()
 			.exceptionHandling()
 				.accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/gov/usds/case_issues/controllers/CsrfController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/CsrfController.java
@@ -1,0 +1,18 @@
+package gov.usds.case_issues.controllers;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Painfully simple controller to allow clients to find out the CSRF token behaviors
+ * that will be accepted by this service.
+ */
+@RestController
+public class CsrfController {
+
+	@GetMapping("/csrf")
+	public CsrfToken getToken(CsrfToken t) {
+		return t;
+	}
+}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -1,5 +1,6 @@
 package gov.usds.case_issues.controllers;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -101,17 +102,28 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putJson_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put("/api/cases/{caseManagementSystemTag}/{caseTypeTag}/{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
 			.contentType(MediaType.APPLICATION_JSON)
+			.with(csrf())
 			.content("[]");
 		perform(jsonPut).andExpect(status().isAccepted());
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putJson_emptyListNoCsrf_forbidden() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content("[]");
+		perform(jsonPut).andExpect(status().isForbidden());
+	}
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put("/api/cases/{caseManagementSystemTag}/{caseTypeTag}/{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
 			.contentType("text/csv")
+			.with(csrf())
 			.content("header1,header2\n");
 		perform(jsonPut).andExpect(status().isAccepted());
 	}
@@ -119,8 +131,9 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_singleCase_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put("/api/cases/{caseManagementSystemTag}/{caseTypeTag}/{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
 			.contentType("text/csv")
+			.with(csrf())
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
@@ -133,6 +146,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	public void putCsv_invalidCreationDate_badRequest() throws Exception {
 		MockHttpServletRequestBuilder jsonPut = put("/api/cases/{caseManagementSystemTag}/{caseTypeTag}/{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
 			.contentType("text/csv")
+			.with(csrf())
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,NOT A DATE,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"

--- a/src/test/java/gov/usds/case_issues/controllers/ResourceControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/ResourceControllerTest.java
@@ -2,9 +2,12 @@ package gov.usds.case_issues.controllers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -91,7 +94,7 @@ public class ResourceControllerTest extends ControllerTestBase {
 			.andExpect(jsonPath("issueClosed").isEmpty());
 		reqBody = new JSONObject();
 		reqBody.put("issueClosed", "2019-07-10T18:11:00-04:00");
-		_mvc.perform(patch(issueUrl).content(reqBody.toString()))
+		_mvc.perform(patch(issueUrl).content(reqBody.toString()).with(csrf()))
 			.andExpect(status().is(HttpStatus.NO_CONTENT.value()))
 		;
 
@@ -121,6 +124,24 @@ public class ResourceControllerTest extends ControllerTestBase {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("snoozeReason").value("In the Mail"))
 		;
+	}
+
+	// not doing every possible entity, but doing all the unsafe operations on at least one resource
+	@Test
+	public void unsafeOperations_noCsrf_forbidden() throws Exception {
+		createFixtureEntities();
+		doCreate(CaseManagementSystem.class, taggedResourceBody("MINE3", "MyCaseManager 3.1", "The manager that manages."),
+				HttpStatus.FORBIDDEN, false);
+		perform(delete(getFixtureCaseManagerUrl()))
+			.andExpect(status().isForbidden());
+		perform(patch(getFixtureCaseManagerUrl()).content("{\"name\": \"Other Name\"}"))
+			.andExpect(status().isForbidden());
+		perform(put(getFixtureCaseManagerUrl()).content("{\"name\": \"Other Name\"}"))
+			.andExpect(status().isForbidden());
+		doCreate(CaseType.class, taggedResourceBody("STD", "Standard Case", "Nothing interesting"),
+				HttpStatus.FORBIDDEN, false);
+		perform(delete(getFixtureCaseTypeUrl()))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test
@@ -218,13 +239,28 @@ public class ResourceControllerTest extends ControllerTestBase {
 		doCreate(TroubleCase.class, new JSONObject(), HttpStatus.FORBIDDEN);
 	}
 
+	private static JSONObject taggedResourceBody(String tag, String name, String description) {
+		JSONObject reqBody = new JSONObject();
+		reqBody.put("tag", tag);
+		reqBody.put("description", description);
+		reqBody.put("name", name);
+		return reqBody;
+	}
+
 	private MockHttpServletResponse doCreate(Class<?> entityType, JSONObject body) throws Exception {
 		return doCreate(entityType, body, HttpStatus.CREATED);
 	}
 
-	private MockHttpServletResponse doCreate(Class<?> entityType, JSONObject body, HttpStatus expectedStatus) throws Exception {
+	private MockHttpServletResponse doCreate(Class<?> entityType, JSONObject body, HttpStatus created) throws Exception {
+		return doCreate(entityType, body, created, true);
+	}
+
+	private MockHttpServletResponse doCreate(Class<?> entityType, JSONObject body, HttpStatus expectedStatus, boolean withCsrf) throws Exception {
 		MockHttpServletRequestBuilder postRequest = post(linkFor(entityType))
 			.content(body.toString());
+		if (withCsrf) {
+			postRequest.with(csrf());
+		}
 		return _mvc.perform(postRequest)
 			.andExpect(status().is(expectedStatus.value()))
 			.andReturn()


### PR DESCRIPTION
Changed the application configuration to require CSRF tokens for all unsafe operations, tested that this actually works, and documented how to obtain and send the tokens from and to the service.