### PR TITLE
Create upload history

### DIFF
--- a/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
@@ -33,6 +33,8 @@ import gov.usds.case_issues.db.model.TroubleCase;
 import gov.usds.case_issues.model.CaseRequest;
 import gov.usds.case_issues.model.CaseSummary;
 import gov.usds.case_issues.services.CaseListService;
+import gov.usds.case_issues.services.CaseListService.CaseGroupInfo;
+import gov.usds.case_issues.services.IssueUploadService;
 import gov.usds.case_issues.validators.TagFragment;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -46,6 +48,8 @@ public class HitlistApiController {
 
 	@Autowired
 	private CaseListService _listService;
+	@Autowired
+	private IssueUploadService _uploadService;
 
 	@GetMapping("search")
 	public List<TroubleCase> getCases(
@@ -86,13 +90,14 @@ public class HitlistApiController {
 	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
 	public ResponseEntity<?> updateIssueListCsv(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
 			@RequestBody InputStream csvStream, @RequestParam(required=false) String uploadSchema) throws IOException {
+		CaseGroupInfo translated = _listService.translatePath(caseManagementSystemTag, caseTypeTag);
 		CsvSchema schema = CsvSchema.emptySchema().withHeader();
 		MappingIterator<Map<String, Object>> valueIterator = new CsvMapper()
 			.readerFor(Map.class)
 			.with(schema)
 			.readValues(csvStream);
 		List<CaseRequest> newIssueCases = processCaseUploads(valueIterator, uploadSchema);
-		_listService.putIssueList(caseManagementSystemTag, caseTypeTag, issueTag, newIssueCases, ZonedDateTime.now());
+		_uploadService.putIssueList(translated, issueTag, newIssueCases, ZonedDateTime.now());
 		return ResponseEntity.accepted().build();
 	}
 
@@ -100,9 +105,10 @@ public class HitlistApiController {
 	@PutMapping(value="/{issueTag}",consumes= {MediaType.APPLICATION_JSON_VALUE})
 	public ResponseEntity<?> updateIssueListJson(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
 			@RequestBody List<Map<String,Object>> jsonData, @RequestParam(required=false) String uploadSchema) throws IOException {
+		CaseGroupInfo translated = _listService.translatePath(caseManagementSystemTag, caseTypeTag);
 		Iterator<Map<String,Object>> valueIterator = jsonData.listIterator();
 		List<CaseRequest> newIssueCases = processCaseUploads(valueIterator, uploadSchema);
-		_listService.putIssueList(caseManagementSystemTag, caseTypeTag, issueTag, newIssueCases, ZonedDateTime.now());
+		_uploadService.putIssueList(translated, issueTag, newIssueCases, ZonedDateTime.now());
 		return ResponseEntity.accepted().build();
 	}
 

--- a/src/main/java/gov/usds/case_issues/db/model/CaseIssueUpload.java
+++ b/src/main/java/gov/usds/case_issues/db/model/CaseIssueUpload.java
@@ -10,20 +10,23 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 /**
  * A record of an issue upload request (successful or unsuccessful).
  */
 @Entity
+@DynamicUpdate
 public class CaseIssueUpload extends UpdatableEntity {
 
 	@ManyToOne(optional=false)
-	@JoinColumn(nullable=false)
+	@JoinColumn(nullable=false, updatable=false)
 	private CaseManagementSystem caseManagementSystem;
 	@ManyToOne(optional=false)
-	@JoinColumn(nullable=false)
+	@JoinColumn(nullable=false, updatable=false)
 	private CaseType caseType;
 	@NotNull
-	@Column(nullable=false)
+	@Column(nullable=false, updatable=false)
 	private String issueType;
 	@NotNull
 	@Column(nullable=false)

--- a/src/main/java/gov/usds/case_issues/db/model/CaseIssueUpload.java
+++ b/src/main/java/gov/usds/case_issues/db/model/CaseIssueUpload.java
@@ -1,0 +1,94 @@
+package gov.usds.case_issues.db.model;
+
+import java.time.ZonedDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+
+/**
+ * A record of an issue upload request (successful or unsuccessful).
+ */
+@Entity
+public class CaseIssueUpload extends UpdatableEntity {
+
+	@ManyToOne(optional=false)
+	@JoinColumn(nullable=false)
+	private CaseManagementSystem caseManagementSystem;
+	@ManyToOne(optional=false)
+	@JoinColumn(nullable=false)
+	private CaseType caseType;
+	@NotNull
+	@Column(nullable=false)
+	private String issueType;
+	@NotNull
+	@Column(nullable=false)
+	private ZonedDateTime effectiveDate;
+	@NotNull
+	@Column(nullable=false)
+	@Enumerated(EnumType.STRING)
+	private UploadStatus uploadStatus;
+	@NotNull
+	@Column(nullable=false)
+	private long uploadedRecordCount;
+	private Long newIssueCount;
+	private Long closedIssueCount;
+
+	private CaseIssueUpload() { 
+		/* for hibernate/JPA */
+		super();
+	}
+
+	public CaseIssueUpload(CaseManagementSystem caseManagementSystem, CaseType caseType, @NotNull String issueType,
+			ZonedDateTime effectiveDate, @NotNull long uploadedRecordCount) {
+		this();
+		this.caseManagementSystem = caseManagementSystem;
+		this.caseType = caseType;
+		this.issueType = issueType;
+		this.uploadedRecordCount = uploadedRecordCount;
+		if (effectiveDate == null) {
+			effectiveDate = ZonedDateTime.now();
+		}
+		this.effectiveDate = effectiveDate;
+		uploadStatus = UploadStatus.STARTED;
+	}
+
+	public CaseManagementSystem getCaseManagementSystem() {
+		return caseManagementSystem;
+	}
+	public CaseType getCaseType() {
+		return caseType;
+	}
+	public String getIssueType() {
+		return issueType;
+	}
+	public ZonedDateTime getEffectiveDate() {
+		return effectiveDate;
+	}
+	public UploadStatus getUploadStatus() {
+		return uploadStatus;
+	}
+	public long getUploadedRecordCount() {
+		return uploadedRecordCount;
+	}
+	public Long getNewIssueCount() {
+		return newIssueCount;
+	}
+	public Long getClosedIssueCount() {
+		return closedIssueCount;
+	}
+	public void setUploadStatus(UploadStatus uploadStatus) {
+		this.uploadStatus = uploadStatus;
+	}
+	public void setClosedIssueCount(long closedIssueCount) {
+		this.closedIssueCount = closedIssueCount;
+	}
+	public void setNewIssueCount(long newIssueCount) {
+		this.newIssueCount = newIssueCount;
+	}
+
+}

--- a/src/main/java/gov/usds/case_issues/db/model/UploadStatus.java
+++ b/src/main/java/gov/usds/case_issues/db/model/UploadStatus.java
@@ -1,0 +1,15 @@
+package gov.usds.case_issues.db.model;
+
+/**
+ * The state of an upload that was requested.
+ */
+public enum UploadStatus {
+	/** The upload request has been received but not completed. */
+	STARTED, 
+	/** The upload was completed without errors. */
+	SUCCESSFUL,
+	/** An exception occured during upload processing */
+	FAILED,
+	/** The upload was canceled (most likely because an uncaught error occurred during processing) */
+	CANCELED;
+}

--- a/src/main/java/gov/usds/case_issues/db/model/WriteOnceEntity.java
+++ b/src/main/java/gov/usds/case_issues/db/model/WriteOnceEntity.java
@@ -2,6 +2,7 @@ package gov.usds.case_issues.db.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -35,17 +36,20 @@ public abstract class WriteOnceEntity {
 		sequenceName="case_issue_entity_id_sequence"
 	)
 	@JsonIgnore
+	@Column(updatable=false)
 	private Long internalId;
+
+	@CreatedBy
+	@Column(updatable=false)
+	private String createdBy;
+
+	@CreatedDate
+	@Column(updatable=false)
+	private Date createdAt;
 
 	public Long getInternalId() {
 		return internalId;
 	}
-
-	@CreatedBy
-	private String createdBy;
-
-	@CreatedDate
-	private Date createdAt;
 
 	public String getCreatedBy() {
 		return createdBy;

--- a/src/main/java/gov/usds/case_issues/db/repositories/CaseIssueUploadRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/CaseIssueUploadRepository.java
@@ -1,0 +1,25 @@
+package gov.usds.case_issues.db.repositories;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.UploadStatus;
+
+/**
+ * CRUD repository for upload objects.
+ */
+public interface CaseIssueUploadRepository extends CrudRepository<CaseIssueUpload, Long> {
+
+	public List<CaseIssueUpload> findAllByCaseManagementSystem(
+			CaseManagementSystem sys);
+	public List<CaseIssueUpload> findAllByCaseManagementSystemAndCaseType(
+			CaseManagementSystem sys, CaseType type);
+	public List<CaseIssueUpload> findAllByCaseManagementSystemAndCaseTypeAndIssueType(
+			CaseManagementSystem sys, CaseType type, String issueType);
+	public List<CaseIssueUpload> findAllByCaseManagementSystemAndCaseTypeAndIssueTypeAndUploadStatus(
+			CaseManagementSystem sys, CaseType type, String issueType, UploadStatus uploadStatus);
+}

--- a/src/main/java/gov/usds/case_issues/db/repositories/CaseIssueUploadRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/CaseIssueUploadRepository.java
@@ -1,6 +1,7 @@
 package gov.usds.case_issues.db.repositories;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 
@@ -21,5 +22,7 @@ public interface CaseIssueUploadRepository extends CrudRepository<CaseIssueUploa
 	public List<CaseIssueUpload> findAllByCaseManagementSystemAndCaseTypeAndIssueType(
 			CaseManagementSystem sys, CaseType type, String issueType);
 	public List<CaseIssueUpload> findAllByCaseManagementSystemAndCaseTypeAndIssueTypeAndUploadStatus(
+			CaseManagementSystem sys, CaseType type, String issueType, UploadStatus uploadStatus);
+	public Optional<CaseIssueUpload> findFirstByCaseManagementSystemAndCaseTypeAndIssueTypeAndUploadStatusOrderByEffectiveDateDesc(
 			CaseManagementSystem sys, CaseType type, String issueType, UploadStatus uploadStatus);
 }

--- a/src/main/java/gov/usds/case_issues/services/CaseListService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseListService.java
@@ -142,15 +142,6 @@ public class CaseListService {
 	 *    values that are set by this method).
 	 * @throws ApiModelNotFoundException if the {@link CaseManagementSystem} or {@link CaseType} could not be found.
 	 */
-	@Transactional(readOnly=false)
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
-	public void putIssueList(String systemTag, String caseTypeTag, String issueTypeTag,
-			List<CaseRequest> newIssueCases, ZonedDateTime eventDate) {
-		CaseGroupInfo translated = translatePath(systemTag, caseTypeTag);
-		CaseIssueUpload uploadInfo = new CaseIssueUpload(translated.getCaseManagementSystem(),
-		    translated.getCaseType(), issueTypeTag, eventDate, newIssueCases.size());
-		putIssueList(uploadInfo, newIssueCases);
-	}
 
 	@Transactional(readOnly=false)
 	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")

--- a/src/main/java/gov/usds/case_issues/services/CaseListService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseListService.java
@@ -20,12 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 import gov.usds.case_issues.config.DataFormatSpec;
 import gov.usds.case_issues.config.WebConfigurationProperties;
 import gov.usds.case_issues.db.model.CaseIssue;
+import gov.usds.case_issues.db.model.CaseIssueUpload;
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
 import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.db.model.UploadStatus;
 import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
 import gov.usds.case_issues.db.repositories.BulkCaseRepository;
 import gov.usds.case_issues.db.repositories.CaseIssueRepository;
+import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
 import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
 import gov.usds.case_issues.db.repositories.CaseSnoozeRepository;
 import gov.usds.case_issues.db.repositories.CaseTypeRepository;
@@ -60,6 +63,8 @@ public class CaseListService {
 	private TroubleCaseRepository _caseRepo;
 	@Autowired
 	private CaseAttachmentService _attachmentService;
+	@Autowired
+	private CaseIssueUploadRepository _uploadRepo;
 	@Autowired
 	private WebConfigurationProperties _webProperties;
 
@@ -140,10 +145,22 @@ public class CaseListService {
 	@Transactional(readOnly=false)
 	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
 	public void putIssueList(String systemTag, String caseTypeTag, String issueTypeTag,
-			Iterable<CaseRequest> newIssueCases, ZonedDateTime eventDate) {
+			List<CaseRequest> newIssueCases, ZonedDateTime eventDate) {
 		CaseGroupInfo translated = translatePath(systemTag, caseTypeTag);
+		CaseIssueUpload uploadInfo = new CaseIssueUpload(translated.getCaseManagementSystem(),
+		    translated.getCaseType(), issueTypeTag, eventDate, newIssueCases.size());
+		putIssueList(uploadInfo, newIssueCases);
+	}
+
+	@Transactional(readOnly=false)
+	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	public CaseIssueUpload putIssueList(CaseIssueUpload translated, List<CaseRequest> newIssueCases) {
+		// convenience aliases to local variables, for use in closures
+		final ZonedDateTime eventDate = translated.getEffectiveDate();
+		final String issueTypeTag = translated.getIssueType();
+
 		List<CaseIssue> currentIssues = _issueRepo.findActiveIssues(translated.getCaseManagementSystem(), translated.getCaseType(),
-				issueTypeTag);
+				translated.getIssueType());
 		Map<String, CaseIssue> currentMap = currentIssues.stream().collect(Collectors.toMap(i->i.getIssueCase().getReceiptNumber(), i->i));
 
 		// build a list containing only CaseSummary objects with no existing CaseIssue
@@ -164,6 +181,8 @@ public class CaseListService {
 		// terminate all the remaining issues in the current collection
 		// this could also be done directly in the database, which might not be a bad idea?
 		currentMap.values().forEach(i -> i.setIssueClosed(eventDate));
+		LOG.info("Closing {} issues", currentMap.size());
+		translated.setClosedIssueCount(currentMap.size());
 
 		// get or create cases
 		HashSet<String> newReceipts = requestedNewIssues.stream().map(CaseRequest::getReceiptNumber)
@@ -203,6 +222,10 @@ public class CaseListService {
 				newIssues.stream()
 			).collect(Collectors.toSet())
 		);
+		translated.setNewIssueCount(existingCases.size() + newIssues.size());
+		translated.setUploadStatus(UploadStatus.SUCCESSFUL);
+		_uploadRepo.save(translated);
+		return translated;
 	}
 
 	public DataFormatSpec getUploadFormat(String uploadFormatId) {

--- a/src/main/java/gov/usds/case_issues/services/IssueUploadService.java
+++ b/src/main/java/gov/usds/case_issues/services/IssueUploadService.java
@@ -1,0 +1,49 @@
+package gov.usds.case_issues.services;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.model.CaseRequest;
+import gov.usds.case_issues.services.CaseListService.CaseGroupInfo;
+
+@Service
+// THIS SERVICE IS NOT TRANSACTIONAL (it launches multiple transactions)
+public class IssueUploadService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(IssueUploadService.class);
+	@Autowired
+	private UploadStatusService _statusService;
+	@Autowired
+	private CaseListService _listService;
+
+	@SuppressWarnings("checkstyle:IllegalCatch")
+	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	public CaseIssueUpload putIssueList(CaseGroupInfo pathInfo, String issueTypeTag, List<CaseRequest> newIssueCases,
+			ZonedDateTime eventDate) {
+		CaseIssueUpload uploadStatus = _statusService.commenceUpload(
+				pathInfo.getCaseManagementSystem(),
+				pathInfo.getCaseType(),
+				issueTypeTag,
+				eventDate,
+				newIssueCases.size());
+		try {
+			LOG.info("Processing upload of {} cases for {}/{}/{}",
+					newIssueCases.size(),
+					uploadStatus.getCaseManagementSystem().getExternalId(),
+					uploadStatus.getCaseType().getExternalId(),
+					uploadStatus.getIssueType());
+			uploadStatus = _listService.putIssueList(uploadStatus, newIssueCases);
+		} catch (Exception e) {
+			LOG.error("Issue upload {} failed!", uploadStatus.getInternalId(), e);
+			uploadStatus = _statusService.failUpload(uploadStatus);
+		}
+		return uploadStatus;
+	}
+}

--- a/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
+++ b/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
@@ -3,6 +3,8 @@ package gov.usds.case_issues.services;
 
 import java.time.ZonedDateTime;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -18,18 +20,22 @@ import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
 @Transactional
 public class UploadStatusService {
 
+	private static final Logger LOG = LoggerFactory.getLogger(UploadStatusService.class);
+
 	@Autowired
 	private CaseIssueUploadRepository _uploadRepository;
 
 	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
 	public CaseIssueUpload commenceUpload(CaseManagementSystem sys, CaseType caseType, String issueType,
 	        ZonedDateTime effectiveDate, int uploadedRecords) {
+		LOG.debug("Saving upload record for {}/{}/{}", sys.getExternalId(), caseType.getExternalId(), issueType);
 		return _uploadRepository.save(
 		    new CaseIssueUpload(sys, caseType, issueType, effectiveDate, uploadedRecords));
 	}
 
 	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
 	public CaseIssueUpload completeUpload(CaseIssueUpload upload, long newIssues, long closedIssues) {
+		LOG.debug("Finalizing upload record {} as success", upload.getInternalId());
 		upload.setUploadStatus(UploadStatus.SUCCESSFUL);
 		upload.setClosedIssueCount(closedIssues);
 		upload.setNewIssueCount(newIssues);
@@ -38,6 +44,7 @@ public class UploadStatusService {
 
 	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
 	public CaseIssueUpload failUpload(CaseIssueUpload upload) {
+		LOG.debug("Finalizing upload record {} as failure", upload.getInternalId());
 		upload.setUploadStatus(UploadStatus.FAILED);
 		return _uploadRepository.save(upload);
 	}

--- a/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
+++ b/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
@@ -1,0 +1,49 @@
+package gov.usds.case_issues.services;
+
+
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
+
+@Service
+@Transactional
+public class UploadStatusService {
+
+	@Autowired
+	private CaseIssueUploadRepository _uploadRepository;
+
+	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
+	public CaseIssueUpload commenceUpload(CaseManagementSystem sys, CaseType caseType, String issueType,
+	        ZonedDateTime effectiveDate, int uploadedRecords) {
+		return _uploadRepository.save(
+		    new CaseIssueUpload(sys, caseType, issueType, effectiveDate, uploadedRecords));
+	}
+
+	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
+	public CaseIssueUpload completeUpload(CaseIssueUpload upload, long newIssues, long closedIssues) {
+		upload.setUploadStatus(UploadStatus.SUCCESSFUL);
+		upload.setClosedIssueCount(closedIssues);
+		upload.setNewIssueCount(newIssues);
+		return _uploadRepository.save(upload);
+	}
+
+	@Transactional(readOnly=false, propagation=Propagation.REQUIRES_NEW)
+	public CaseIssueUpload failUpload(CaseIssueUpload upload) {
+		upload.setUploadStatus(UploadStatus.FAILED);
+		return _uploadRepository.save(upload);
+	}
+
+	public CaseIssueUpload readUploadInformation(Long id) {
+		return _uploadRepository.findById(id).orElseThrow(
+			() -> new IllegalArgumentException("Upload information not found"));
+	}
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -293,3 +293,63 @@ databaseChangeLog:
             tableName: case_attachment_association
             constraint_name: uk__case_attachment_association
             columnNames: snooze_internal_id, attachment_internal_id
+  - changeSet:
+      id: issue-upload-log
+      author: ben.warfield@usds.dhs.gov
+      comment: Record details about each upload of new issues/cases.
+      changes:
+        - createTable:
+            tableName: case_issue_upload
+            remarks: Information about when case issues were uploaded.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column:
+                  name: case_management_system_internal_id
+                  remarks: The case management system where the uploaded cases are tracked outside of this application.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__case_issue_upload__case_management_system
+                    references: case_management_system
+              - column:
+                  name: case_type_internal_id
+                  remarks: What type of cases the uploaded issues are associated with (e.g. what form or what category of letter or inquiry).
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__case_issue_upload__case_type
+                    references: case_type
+              - column:
+                  name: issue_type
+                  type: *string
+                  remarks: The type of this issue, as a URL-safe string (e.g. "AGING").
+              - column:
+                  name: effective_date
+                  type: *user_date
+                  remarks: The effective date of this upload (will match issue_created/issue_closed in case_issue; likely but not necessarily the same as created_at).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: upload_status
+                  type: *string
+                  remarks: The current status (e.g. in progress/completed/error) of this upload.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: uploaded_record_count
+                  type: bigint
+                  remarks: The number of records (CSV rows or JSON objects) in the upload request.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: new_issue_count
+                  type: bigint
+                  remarks: The number of new issues created by this request (if it was successfully processed at all).
+              - column:
+                  name: closed_issue_count
+                  type: bigint
+                  remarks: The number of existing issues closed by this request (if it was successfully processed at all).

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -1,5 +1,7 @@
 package gov.usds.case_issues.controllers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -11,25 +13,34 @@ import java.time.ZonedDateTime;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import gov.usds.case_issues.db.model.CaseIssueUpload;
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
 import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.services.UploadStatusService;
 
 @WithMockUser(username = "default_hitlist_user", authorities = "READ_CASES")
 public class HitlistApiControllerTest extends ControllerTestBase {
 
+	private static final String VALUE_ISSUE_TYPE = "WONKY";
 	private static final String VALID_CASE_TYPE = "C1";
 	private static final String VALID_CASE_MGT_SYS = "F1";
 	private static final String API_PATH = "/api/cases/{caseManagementSystemTag}/{caseTypeTag}/";
+	private static final String ISSUE_UPLOAD_PATH = API_PATH + "{issueTag}";
 	private static final String CASE_TYPE_NOPE = "Case Type 'NOPE' was not found";
 	private static final String CASE_MANAGEMENT_SYSTEM_NOPE = "Case Management System 'NOPE' was not found";
 
 	private CaseManagementSystem _system;
 	private CaseType _type;
+
+	@Autowired
+	private UploadStatusService _uploadService;
 
 	@Before
 	public void resetDb() {
@@ -102,56 +113,55 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putJson_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType(MediaType.APPLICATION_JSON)
-			.with(csrf())
+		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE)
 			.content("[]");
 		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(0, 0, 0);
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putJson_emptyListNoCsrf_forbidden() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+		MockHttpServletRequestBuilder jsonPut = put(ISSUE_UPLOAD_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE, VALUE_ISSUE_TYPE)
 			.contentType(MediaType.APPLICATION_JSON)
 			.content("[]");
 		perform(jsonPut).andExpect(status().isForbidden());
+		assertEquals("No upload records should exist",
+				0, _uploadService.getUploadHistory(_system, _type).size());
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType("text/csv")
-			.with(csrf())
+		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
 			.content("header1,header2\n");
 		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(0, 0, 0);
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_singleCase_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType("text/csv")
-			.with(csrf())
+		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
 			);
 		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(1, 1, 0);
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_invalidCreationDate_badRequest() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put("/api/cases/{caseManagementSystemTag}/{caseTypeTag}/{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType("text/csv")
-			.with(csrf())
+		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,NOT A DATE,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
 			);
 		perform(jsonPut).andExpect(status().isBadRequest());
+		assertEquals("No upload records should exist",
+			0, _uploadService.getUploadHistory(_system, _type).size());
 	}
 
 	@Test
@@ -185,6 +195,15 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		_dataService.snoozeCase(case2);
 	}
 
+	private void checkUploadRecord(int recordCount, int newIssues, int closedIssues) {
+		CaseIssueUpload uploadInfo = _uploadService.getLastUpload(_system, _type, VALUE_ISSUE_TYPE);
+		assertNotNull(uploadInfo);
+		assertEquals(UploadStatus.SUCCESSFUL, uploadInfo.getUploadStatus());
+		assertEquals(newIssues, uploadInfo.getNewIssueCount().intValue());
+		assertEquals(closedIssues, uploadInfo.getClosedIssueCount().intValue());
+		assertEquals(recordCount, uploadInfo.getUploadedRecordCount());
+	}
+
 	private static MockHttpServletRequestBuilder doSearch(String cmsTag, String ctTag, String queryString) {
 		return get(API_PATH + "search", cmsTag, ctTag).param("query", queryString);
 	}
@@ -198,6 +217,12 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 
 	private static MockHttpServletRequestBuilder getSummary(String cmsTag, String ctTag) {
 		return get(API_PATH + "summary", cmsTag, ctTag);
+	}
+
+	private static MockHttpServletRequestBuilder putIssues(String contentType) {
+		return put(ISSUE_UPLOAD_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE, VALUE_ISSUE_TYPE)
+			.contentType(contentType)
+			.with(csrf());
 	}
 
 }

--- a/src/test/java/gov/usds/case_issues/controllers/LoginRedirectControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/LoginRedirectControllerTest.java
@@ -16,8 +16,9 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.web.util.NestedServletException;
 
 import gov.usds.case_issues.config.WebConfigurationProperties;
+import gov.usds.case_issues.test_util.MockConfig;
 
-@ActiveProfiles("mock-properties")
+@ActiveProfiles(MockConfig.MOCK_PROPERTIES_PROFILE)
 public class LoginRedirectControllerTest extends ControllerTestBase {
 
 	private static final String[] ALLOWED_ORIGINS = {

--- a/src/test/java/gov/usds/case_issues/services/IssueUploadServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/IssueUploadServiceTest.java
@@ -1,0 +1,76 @@
+package gov.usds.case_issues.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.db.repositories.CaseIssueRepository;
+import gov.usds.case_issues.model.CaseRequest;
+import gov.usds.case_issues.services.CaseListService.CaseGroupInfo;
+import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
+import gov.usds.case_issues.test_util.MockConfig;
+
+@ActiveProfiles(MockConfig.WRAPPED_REPOSITORIES_PROFILE)
+@WithMockUser(authorities="UPDATE_ISSUES")
+public class IssueUploadServiceTest extends CaseIssueApiTestBase {
+
+	@Autowired
+	private IssueUploadService _uploadService;
+	@Autowired
+	private UploadStatusService _statusService;
+	@Autowired
+	private CaseIssueRepository _wrappedIssueRepo;
+	
+	private static final Long ZERO = Long.valueOf(0);
+
+	private ZonedDateTime _now;
+	private CaseManagementSystem _system;
+	private CaseType _type;
+
+	@Before
+	public void reset() {
+		truncateDb();
+		_now = ZonedDateTime.now();
+		_system = _dataService.ensureCaseManagementSystemInitialized("BIPPITY", "Fred", null);
+		_type = _dataService.ensureCaseTypeInitialized("BOPPITY", "An IRS form", "Look it up");
+	}
+
+	@Test
+	public void putIssueList_emptyList_expectedResult() {
+		CaseIssueUpload uploaded = _uploadService.putIssueList(new CaseGroupInfo(_system, _type), "BOOP", Collections.emptyList(), _now);
+		assertEquals(UploadStatus.SUCCESSFUL, uploaded.getUploadStatus());
+		assertEquals(ZERO, uploaded.getNewIssueCount());
+		assertEquals(ZERO, uploaded.getNewIssueCount());
+		assertEquals(0, uploaded.getUploadedRecordCount());
+		assertEquals(_now, uploaded.getEffectiveDate());
+	}
+
+	@Test
+	public void putIssueList_exception_expectedResult() {
+		Mockito.when(_wrappedIssueRepo.findActiveIssues(_system, _type, "BOOP"))
+			.thenThrow(new IllegalArgumentException("check out this unchecked exception"));
+		List<CaseRequest> requested = Collections.emptyList();
+		CaseIssueUpload uploaded = _uploadService.putIssueList(new CaseGroupInfo(_system, _type), "BOOP", requested, _now);
+		assertEquals(UploadStatus.FAILED, uploaded.getUploadStatus());
+		CaseIssueUpload refetched = _statusService.readUploadInformation(uploaded.getInternalId());
+		assertNotNull(refetched);
+		assertEquals(UploadStatus.FAILED, refetched.getUploadStatus());
+		assertNull(refetched.getClosedIssueCount());
+		assertNull(refetched.getNewIssueCount());
+	}
+}

--- a/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
@@ -1,0 +1,91 @@
+package gov.usds.case_issues.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
+import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
+
+@SuppressWarnings("checkstyle:MagicNumber")
+public class UploadStatusServiceTest extends CaseIssueApiTestBase {
+
+	@Autowired
+	private UploadStatusService _service;
+	@Autowired
+	private CaseIssueUploadRepository _repo;
+	
+	@Before
+	public void clear() {
+		truncateDb();
+	}
+
+	@Test
+	public void commenceUpload_validInput_recordCreated() {
+		CaseIssueUpload uploadInfo = initUpload();
+		assertEquals(UploadStatus.STARTED, uploadInfo.getUploadStatus());
+		assertEquals(42, uploadInfo.getUploadedRecordCount());
+		assertTrue(0 < uploadInfo.getInternalId());
+		assertTrue(_repo.findById(uploadInfo.getInternalId()).isPresent());
+	}
+
+	@Test
+	public void completeUpload_validInput_recordUpdated() {
+		CaseIssueUpload uploadInfo = initUpload();
+		Long id = uploadInfo.getInternalId();
+		assertEquals(UploadStatus.STARTED, uploadInfo.getUploadStatus());
+		assertNull(uploadInfo.getNewIssueCount());
+		uploadInfo = _service.completeUpload(uploadInfo, 25, 37);
+		assertEquals(id, uploadInfo.getInternalId());
+		Optional<CaseIssueUpload> found = _repo.findById(id);
+		assertTrue(found.isPresent());
+		assertEquals(UploadStatus.SUCCESSFUL, found.get().getUploadStatus());
+		assertNotNull(uploadInfo.getNewIssueCount());
+		assertEquals(25L, uploadInfo.getNewIssueCount().longValue());
+		assertEquals(37L, uploadInfo.getClosedIssueCount().longValue());
+	}
+
+	@Test
+	public void failUpload_validInput_recordUpdated() {
+		CaseIssueUpload uploadInfo = initUpload();
+		_service.failUpload(uploadInfo);
+		Optional<CaseIssueUpload> found = _repo.findById(uploadInfo.getInternalId());
+		assertTrue(found.isPresent());
+		assertEquals(UploadStatus.FAILED, found.get().getUploadStatus());
+	}
+
+	@Test
+	public void readUploadInformation_validId_recordFound() {
+		Long id = initUpload().getInternalId();
+		CaseIssueUpload uploadInfo = _service.readUploadInformation(id);
+		assertEquals(UploadStatus.STARTED, uploadInfo.getUploadStatus());
+		assertEquals(42, uploadInfo.getUploadedRecordCount());
+		assertTrue(0 < uploadInfo.getInternalId());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void readUploadInformation_invalidId_exception() {
+		_service.readUploadInformation(10003L);
+	}
+
+	private CaseIssueUpload initUpload() {
+		CaseManagementSystem sys = _dataService.ensureCaseManagementSystemInitialized("YABBA", "Yet Another Big Bad Aggregator");
+		CaseType caseType = _dataService.ensureCaseTypeInitialized("DABBA", "Definitely Also Big Bad and Awesome");
+		CaseIssueUpload uploadInfo = _service.commenceUpload(sys, caseType, "DOO", ZonedDateTime.now(), 42);
+		return uploadInfo;
+	}
+
+	
+}

--- a/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
@@ -63,7 +63,9 @@ public class UploadStatusServiceTest extends CaseIssueApiTestBase {
 		Long id = uploadInfo.getInternalId();
 		assertEquals(UploadStatus.STARTED, uploadInfo.getUploadStatus());
 		assertNull(uploadInfo.getNewIssueCount());
-		uploadInfo = _service.completeUpload(uploadInfo, 25, 37);
+		uploadInfo.setNewIssueCount(25L);
+		uploadInfo.setClosedIssueCount(37);
+		uploadInfo = _service.completeUpload(uploadInfo);
 		assertEquals(id, uploadInfo.getInternalId());
 		Optional<CaseIssueUpload> found = _repo.findById(id);
 		assertTrue(found.isPresent());

--- a/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/UploadStatusServiceTest.java
@@ -1,11 +1,13 @@
 package gov.usds.case_issues.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -16,8 +18,11 @@ import gov.usds.case_issues.db.model.CaseIssueUpload;
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
 import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.db.repositories.CaseIssueRepository;
 import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
+import gov.usds.case_issues.test_util.TransactionTestingService;
+import gov.usds.case_issues.test_util.TransactionTestingService.ExpectedException;
 
 @SuppressWarnings("checkstyle:MagicNumber")
 public class UploadStatusServiceTest extends CaseIssueApiTestBase {
@@ -26,10 +31,21 @@ public class UploadStatusServiceTest extends CaseIssueApiTestBase {
 	private UploadStatusService _service;
 	@Autowired
 	private CaseIssueUploadRepository _repo;
+	@Autowired
+	private CaseIssueRepository _issueRepo;
+	@Autowired
+	private TransactionTestingService _transactionTester;
+
+	// re-initialized for each test
+	private CaseManagementSystem _sys;
+	private CaseType _caseType;
 	
 	@Before
 	public void clear() {
 		truncateDb();
+		_sys = _dataService.ensureCaseManagementSystemInitialized("YABBA", "Yet Another Big Bad Aggregator");
+		_caseType = _dataService.ensureCaseTypeInitialized("DABBA", "Definitely Also Big Bad and Awesome");
+
 	}
 
 	@Test
@@ -80,11 +96,44 @@ public class UploadStatusServiceTest extends CaseIssueApiTestBase {
 		_service.readUploadInformation(10003L);
 	}
 
+	/** This doesn't follow the standard naming convention because it's not standard:
+	 * we're just checking to make sure that the Spring transaction manager is working
+	 * at all, so that if some wiring gets broken, there's a simple test that fails in
+	 * a simple way, as well as many many other tests that fail in less simple ways.
+	 */
+	@Test
+	public void transactionSanityTest() {
+		boolean caught = false;
+		try {
+			_transactionTester.initThenThrow("HELLO");
+		} catch (ExpectedException e) {
+			caught = true; // this is mostly just to keep checkstyle happy, but it's not the worst sanity check ever.
+		}
+		assertTrue(caught);
+		assertFalse(_transactionTester.checkForCaseManagementSystem("HELLO"));
+	}
+
+	@Test
+	public void uploadSimulation_exceptionThrown_uploadRecordExists() {
+		boolean caught = false;
+		try {
+			_transactionTester.fakeUploadFailure(_sys, _caseType, "WOTCHER");
+		} catch (ExpectedException e) {
+			caught = true; // this is mostly just to keep checkstyle happy, but it's not the worst sanity check ever.
+		}
+		assertTrue(caught);
+		assertFalse("No issues should be found", _issueRepo.findAll().iterator().hasNext());
+		List<CaseIssueUpload> uploads = _repo.findAllByCaseManagementSystemAndCaseType(_sys, _caseType);
+		assertEquals("One upload record should be found", 1, uploads.size());
+		CaseIssueUpload upload = uploads.get(0);
+		assertEquals(UploadStatus.STARTED, upload.getUploadStatus());
+		assertEquals(TransactionTestingService.ARBITRARY_UPLOAD_COUNT, upload.getUploadedRecordCount());
+		assertNull(upload.getNewIssueCount());
+		assertNull(upload.getClosedIssueCount());
+	}
+
 	private CaseIssueUpload initUpload() {
-		CaseManagementSystem sys = _dataService.ensureCaseManagementSystemInitialized("YABBA", "Yet Another Big Bad Aggregator");
-		CaseType caseType = _dataService.ensureCaseTypeInitialized("DABBA", "Definitely Also Big Bad and Awesome");
-		CaseIssueUpload uploadInfo = _service.commenceUpload(sys, caseType, "DOO", ZonedDateTime.now(), 42);
-		return uploadInfo;
+		return _service.commenceUpload(_sys, _caseType, "DOO", ZonedDateTime.now(), 42);
 	}
 
 	

--- a/src/test/java/gov/usds/case_issues/test_util/FixtureDataInitializationService.java
+++ b/src/test/java/gov/usds/case_issues/test_util/FixtureDataInitializationService.java
@@ -55,6 +55,10 @@ public class FixtureDataInitializationService {
 		return _caseManagementSystemRepo.save(new CaseManagementSystem(tag, name, description));
 	}
 
+	public CaseType ensureCaseTypeInitialized(String tag, String name) {
+		return ensureCaseTypeInitialized(tag, name, null);
+	}
+
 	public CaseType ensureCaseTypeInitialized(String tag, String name, String description) {
 		LOG.debug("(Re)initializing case type '{}'", tag);
 		Optional<CaseType> found = _caseTypeRepository.findByExternalId(tag);

--- a/src/test/java/gov/usds/case_issues/test_util/MockConfig.java
+++ b/src/test/java/gov/usds/case_issues/test_util/MockConfig.java
@@ -1,10 +1,15 @@
 package gov.usds.case_issues.test_util;
 
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import gov.usds.case_issues.config.WebConfigurationProperties;
+import gov.usds.case_issues.db.repositories.CaseIssueRepository;
+import gov.usds.case_issues.db.repositories.CaseIssueUploadRepository;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -18,10 +23,42 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 public class MockConfig {
 
+	private static final Logger LOG = LoggerFactory.getLogger(MockConfig.class);
+
+	/**
+	 * A profile that provides a mock of the {@link WebConfigurationProperties} object, to allow
+	 * easier testing the behavior of things that depend on the values stored therein.
+	 */
+	public static final String MOCK_PROPERTIES_PROFILE = "mock-properties";
+	/**
+	 * A profile that provides wrapped versions of some or all Spring Data JPA repositories,
+	 * to test (roughly) database interactions failures.
+	 * Add additional repositories to this as needed (should not be needed often).
+	 */
+	public static final String WRAPPED_REPOSITORIES_PROFILE = "mock-repositories";
+
 	@Bean
 	@Primary
-	@Profile("mock-properties")
+	@Profile(MOCK_PROPERTIES_PROFILE)
 	public WebConfigurationProperties getMockProperties() {
 		return Mockito.mock(WebConfigurationProperties.class);
+	}
+
+	@Bean
+	@Primary
+	@Profile(WRAPPED_REPOSITORIES_PROFILE)
+	public CaseIssueRepository getIssueRepo(CaseIssueRepository repo) {
+		// see also https://github.com/spring-projects/spring-boot/issues/7033
+		LOG.info("Wiring up wrapper around {}", repo);
+		return Mockito.mock(CaseIssueRepository.class, AdditionalAnswers.delegatesTo(repo));
+	}
+
+	@Bean
+	@Primary
+	@Profile(WRAPPED_REPOSITORIES_PROFILE)
+	public CaseIssueUploadRepository getUploadRepo(CaseIssueUploadRepository repo) {
+		// see also https://github.com/spring-projects/spring-boot/issues/7033
+		LOG.info("Wiring up wrapper around {}", repo);
+		return Mockito.mock(CaseIssueUploadRepository.class, AdditionalAnswers.delegatesTo(repo));
 	}
 }

--- a/src/test/java/gov/usds/case_issues/test_util/TransactionTestingService.java
+++ b/src/test/java/gov/usds/case_issues/test_util/TransactionTestingService.java
@@ -1,0 +1,62 @@
+package gov.usds.case_issues.test_util;
+
+
+import java.time.ZonedDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
+import gov.usds.case_issues.services.UploadStatusService;
+
+/**
+ * Testing utility for doing tests that require nested transactions or controlled
+ * failures inside a transaction boundary.
+ */
+@Service
+@Transactional(readOnly=false)
+public class TransactionTestingService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TransactionTestingService.class);
+
+	public static final int ARBITRARY_UPLOAD_COUNT = 3823;
+	@Autowired
+	private UploadStatusService _statusService;
+	@Autowired
+	private FixtureDataInitializationService _dataService;
+	@Autowired
+	private CaseManagementSystemRepository _caseManagerRepo;
+
+	public void initThenThrow(String systemTag) {
+		_dataService.ensureCaseManagementSystemInitialized(systemTag, "The system named " + systemTag);
+		throw new ExpectedException("Expected failure of method call");
+	}
+
+	public void fakeUploadFailure(CaseManagementSystem sys, CaseType caseType, String issueType) {
+		LOG.info("Commencing fake upload");
+		_statusService.commenceUpload(sys, caseType, issueType, ZonedDateTime.now(), ARBITRARY_UPLOAD_COUNT);
+		LOG.info("Creating fake upload records");
+		TroubleCase tc = _dataService.initCase(sys, "ABC123", caseType, ZonedDateTime.now());
+		_dataService.initIssue(tc, issueType, ZonedDateTime.now(), null);
+		throw new ExpectedException("Synthetic failure of fake upload process");
+	}
+
+	public boolean checkForCaseManagementSystem(String tag) {
+		return _caseManagerRepo.findByExternalId(tag).isPresent();
+	}
+
+	/** An exception class to be thrown by our test methods */
+	@SuppressWarnings("serial")
+	public class ExpectedException extends RuntimeException {
+
+		public ExpectedException(String string) {
+			super(string);
+		}
+	}
+}


### PR DESCRIPTION
Added entities and service/controller changes so that a record is created each time we send a PUT request to an issue list.

TODO:
* [ ] test non-trivial add/subtract cases
* [x] test unhappy paths