### PR TITLE
Spring Boot Actuator configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'checkstyle'
 	id 'jacoco'
 	id 'org.sonarqube'  version '2.7.1'
+	id "com.gorylenko.gradle-git-properties" version "2.2.0"
 }
 
 apply plugin: 'io.spring.dependency-management'
@@ -84,4 +85,8 @@ check.dependsOn jacocoTestCoverageVerification
 task copyDeps(type: Copy) {
 	from configurations.runtimeClasspath
 	into "${project.buildDir}/libs/"
+}
+
+springBoot {
+	buildInfo()
 }

--- a/src/main/java/gov/usds/case_issues/authorization/CaseIssuePermission.java
+++ b/src/main/java/gov/usds/case_issues/authorization/CaseIssuePermission.java
@@ -14,6 +14,8 @@ public enum CaseIssuePermission implements GrantedAuthority {
 	UPDATE_STRUCTURE,
 	/** The ability to update an issue list using the PUT endpoints (ideally, only held by automated processes) */
 	UPDATE_ISSUES,
+	/** The ability to read and potentially write system-management ("actuator") endpoints. */
+	MANAGE_APPLICATION,
 	;
 
 	@Override

--- a/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/SecurityConfig.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -48,8 +50,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.httpStrictTransportSecurity().and()
 				.and()
 			.authorizeRequests()
-				.antMatchers("/actuator/health", "/health")
+				.antMatchers(HttpMethod.GET, "/health", "/favicon.ico")
 					.permitAll()
+				.requestMatchers(EndpointRequest.to(InfoEndpoint.class))
+					.permitAll()
+				.requestMatchers(EndpointRequest.toAnyEndpoint())
+					.hasAuthority(CaseIssuePermission.MANAGE_APPLICATION.name())
 				.anyRequest()
 					.authenticated()
 				.and()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,8 @@ logging:
       # org.hibernate.type: TRACE
       # org.springframework.data.rest=DEBUG
       gov.usds: DEBUG
+management:
+  info.git.mode: full
 web-customization:
   cors-origins:
     - http://localhost:3000
@@ -29,6 +31,9 @@ web-customization:
     - name: service
       grants:
         - UPDATE_ISSUES
+    - name: devops
+      grants:
+        - MANAGE_APPLICATION
 access-log-format: combined
 sample-data:
   case-management-systems:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,10 @@ spring:
 logback:
   access:
     enabled: true
+management:
+  endpoints.web.exposure:
+    exclude: shutdown,env
+    include: '*'
+  endpoint:
+    health:
+      show-details: always

--- a/src/test/java/gov/usds/case_issues/controllers/ActuatorPermissionsTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/ActuatorPermissionsTest.java
@@ -1,0 +1,70 @@
+package gov.usds.case_issues.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WithAnonymousUser
+public class ActuatorPermissionsTest extends ControllerTestBase {
+
+	@Value("${management.endpoints.web.base-path:/actuator}")
+	private String _basePath;
+
+	@Test
+	public void getHealth_anonymous_forbidden() throws Exception {
+		doActuatorGet("health").andExpect(status().isForbidden())
+		;
+	}
+
+	@Test
+	@WithMockUser(authorities="UPDATE_STRUCTURE") // a highly-privileged but not devops user
+	public void getHealth_contentAdmin_forbidden() throws Exception {
+		doActuatorGet("health").andExpect(status().isForbidden());
+	}
+
+	@Test
+	@WithMockUser(authorities="MANAGE_APPLICATION")
+	public void getHealth_systemAdmin_fullResult() throws Exception {
+		doActuatorGet("health")
+			.andExpect(status().isOk())
+			.andExpect(content().json("{\"status\": \"UP\", \"details\": {\"db\": {\"status\": \"UP\"}}}", false))
+		;
+	}
+
+	@Test
+	public void getInfo_anonymous_fullResult() throws Exception {
+		doActuatorGet("info")
+			.andExpect(status().isOk())
+			// if run in the IDE, this does not pick up properties
+			// in any case we do not need to test the functioning of library code
+			.andExpect(content().json("{}", false))
+		;
+	}
+
+	@Test
+	public void getLoggers_anonymous_forbidden() throws Exception {
+		doActuatorGet("loggers").andExpect(status().isForbidden());
+	}
+
+	@Test
+	@WithMockUser(authorities="MANAGE_APPLICATION")
+	public void getLoggers_systemAdmin_ok() throws Exception {
+		doActuatorGet("loggers").andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser(authorities="UPDATE_STRUCTURE") // a highly-privileged but not devops user
+	public void getLoggers_contentAdmin_forbidden() throws Exception {
+		doActuatorGet("loggers").andExpect(status().isForbidden());
+	}
+
+	private ResultActions doActuatorGet(String id) throws Exception {
+		return perform(get(_basePath + "/{id}", id));
+	}
+}

--- a/src/test/java/gov/usds/case_issues/controllers/ApiNavigatorPermissionsTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/ApiNavigatorPermissionsTest.java
@@ -34,6 +34,11 @@ public class ApiNavigatorPermissionsTest extends ControllerTestBase {
 	}
 
 	@Test
+	public void getFavicon_anonymous_ok() throws Exception {
+		perform(get("/favicon.ico")).andExpect(status().isOk());
+	}
+
+	@Test
 	public void getSwaggerUi_anonymous_ok() throws Exception {
 		perform(get("/swagger-ui.html")).andExpect(status().isOk());
 	}

--- a/src/test/java/gov/usds/case_issues/controllers/OneShotControllersTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/OneShotControllersTest.java
@@ -76,4 +76,17 @@ public class OneShotControllersTest extends ControllerTestBase {
 	public void getCsrf_badOrigin_forbidden() throws Exception {
 		perform(getCsrf().header("Origin", ORIGIN_NOT_OK)).andExpect(status().isForbidden());
 	}
+
+	@Test
+	@WithAnonymousUser
+	public void getHealth_anonymous_okResult() throws Exception {
+		perform(get("/health")).andExpect(status().isOk()).andExpect(content().string(""));
+	}
+
+	@Test
+	@WithMockUser
+	public void getHealth_loggedInUser_okResult() throws Exception {
+		perform(get("/health")).andExpect(status().isOk()).andExpect(content().string(""));
+	}
+
 }


### PR DESCRIPTION
Added configuration to expose (but protect with appropriate authorization checks) the Spring Boot Actuator endpoints that expose useful admin-level information that an administrator might want to see and manipulate.

Exposed build information to the entire world, so that it can be read by build automation to verify that a deployment succeeded.