### PR TITLE
List fetch refactor

### DIFF
--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -65,12 +65,6 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
-		name = "snoozed.count",
-		query = "SELECT count(1) as entity_count from " + TroubleCase.CASE_DTO_CTE
-			  + "WHERE last_snooze_end >= CURRENT_TIMESTAMP ",
-		resultSetMapping = "rowCount"
-	),
-	@NamedNativeQuery(
 		name = "unSnoozedAfter",
 		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
 				+ "WHERE (last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP) "
@@ -79,12 +73,6 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 				+ "ORDER BY case_creation ASC, internal_id ASC "
 				+ "LIMIT :size",
 		resultSetMapping="snoozeCaseMapping"
-	),
-	@NamedNativeQuery(
-		name = "unSnoozed.count",
-		query = "SELECT count(1) as entity_count from " + TroubleCase.CASE_DTO_CTE
-			  + "WHERE last_snooze_end is null or last_snooze_end < CURRENT_TIMESTAMP ",
-		resultSetMapping = "rowCount"
 	),
 	@NamedNativeQuery(
 		name = "summary",
@@ -98,10 +86,6 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 		name="snoozeCaseMapping",
 		entities=@EntityResult(entityClass=TroubleCase.class),
 		columns=@ColumnResult(name="last_snooze_end", type=ZonedDateTime.class)
-	),
-	@SqlResultSetMapping(
-		name="rowCount",
-		columns=@ColumnResult(name="entity_count", type=Long.class)
 	),
 })
 public class TroubleCase extends UpdatableEntity {

--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -38,40 +38,36 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 @TypeDef(name="json", typeClass=JsonStringType.class)
 @NamedNativeQueries({
 	@NamedNativeQuery(
-		name = "snoozed",
+		name = "snoozedFirstPage",
 		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
 				+ "WHERE last_snooze_end >= CURRENT_TIMESTAMP "
-				+ "ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC "
-				+ "LIMIT :size",
+				+ TroubleCase.SNOOZED_CASE_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
-		name = "snoozedAfter",
+		name = "snoozedLaterPage",
 		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
 				+ "WHERE last_snooze_end >= CURRENT_TIMESTAMP "
 				+ "AND last_snooze_end >= :lastSnoozeEnd "
 				+ "AND case_creation >= :caseCreation "
 				+ "AND internal_id != :internalId "
-				+ "ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC "
-				+ "LIMIT :size",
+				+ TroubleCase.SNOOZED_CASE_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
-		name = "unSnoozed",
+		name = "notCurrentlySnoozedFirstPage",
 		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
 				+ "WHERE last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP "
-				+ "ORDER BY case_creation ASC, internal_id ASC "
-				+ "LIMIT :size",
+				+ TroubleCase.ACTIVE_CASE_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
-		name = "unSnoozedAfter",
+		name = "notCurrentlySnoozedLaterPage",
 		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
 				+ "WHERE (last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP) "
 				+ "AND case_creation >= :caseCreation "
 				+ "AND internal_id != :internalId "
-				+ "ORDER BY case_creation ASC, internal_id ASC "
-				+ "LIMIT :size",
+				+ TroubleCase.ACTIVE_CASE_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
@@ -106,6 +102,12 @@ public class TroubleCase extends UpdatableEntity {
 			+ "where c.internal_id=openissues1_.issue_case_internal_id "
 			+ "and ( openissues1_.issue_closed is null)"
 		+ ")";
+	public static final String ACTIVE_CASE_POSTAMBLE =
+		"  ORDER BY case_creation ASC, internal_id ASC "
+		+ "LIMIT :size";
+	public static final String SNOOZED_CASE_POSTAMBLE =
+		"  ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC "
+		+ "LIMIT :size";
 	public static final String CASE_DTO_CTE = "(" + CASE_DTO_QUERY + ") as trouble_case_dto ";
 
 	@NaturalId

--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -39,35 +39,32 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 @NamedNativeQueries({
 	@NamedNativeQuery(
 		name = "snoozedFirstPage",
-		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
-				+ "WHERE last_snooze_end >= CURRENT_TIMESTAMP "
-				+ TroubleCase.SNOOZED_CASE_POSTAMBLE,
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
 		name = "snoozedLaterPage",
-		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
-				+ "WHERE last_snooze_end >= CURRENT_TIMESTAMP "
-				+ "AND last_snooze_end >= :lastSnoozeEnd "
-				+ "AND case_creation >= :caseCreation "
-				+ "AND internal_id != :internalId "
-				+ TroubleCase.SNOOZED_CASE_POSTAMBLE,
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_CONSTRAINT
+				+ TroubleCase.SNOOZED_PAGE_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
 		name = "notCurrentlySnoozedFirstPage",
-		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
-				+ "WHERE last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP "
-				+ TroubleCase.ACTIVE_CASE_POSTAMBLE,
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.NOT_SNOOZED_NOW_CONSTRAINT
+				+ TroubleCase.NOT_SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
 		name = "notCurrentlySnoozedLaterPage",
-		query = "SELECT * FROM " + TroubleCase.CASE_DTO_CTE
-				+ "WHERE (last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP) "
-				+ "AND case_creation >= :caseCreation "
-				+ "AND internal_id != :internalId "
-				+ TroubleCase.ACTIVE_CASE_POSTAMBLE,
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.NOT_SNOOZED_NOW_CONSTRAINT
+				+ TroubleCase.NOT_SNOOZED_NOW_PAGE_CONSTRAINT
+				+ TroubleCase.NOT_SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
 	@NamedNativeQuery(
@@ -102,13 +99,22 @@ public class TroubleCase extends UpdatableEntity {
 			+ "where c.internal_id=openissues1_.issue_case_internal_id "
 			+ "and ( openissues1_.issue_closed is null)"
 		+ ")";
-	public static final String ACTIVE_CASE_POSTAMBLE =
+	public static final String NOT_SNOOZED_NOW_CONSTRAINT = " (last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP) ";
+	public static final String SNOOZED_NOW_CONSTRAINT = " last_snooze_end >= CURRENT_TIMESTAMP ";
+	public static final String NOT_SNOOZED_NOW_PAGE_CONSTRAINT =
+			"  AND case_creation >= :caseCreation "
+			+ "AND internal_id != :internalId ";
+	public static final String SNOOZED_PAGE_CONSTRAINT =
+			"  AND last_snooze_end >= :lastSnoozeEnd "
+			+ TroubleCase.NOT_SNOOZED_NOW_PAGE_CONSTRAINT;
+	public static final String NOT_SNOOZED_NOW_POSTAMBLE =
 		"  ORDER BY case_creation ASC, internal_id ASC "
 		+ "LIMIT :size";
-	public static final String SNOOZED_CASE_POSTAMBLE =
+	public static final String SNOOZED_NOW_POSTAMBLE =
 		"  ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC "
 		+ "LIMIT :size";
 	public static final String CASE_DTO_CTE = "(" + CASE_DTO_QUERY + ") as trouble_case_dto ";
+	public static final String CASE_SELECT_STEM = "SELECT * FROM" + CASE_DTO_CTE + " WHERE ";
 
 	@NaturalId
 	@ManyToOne(optional=false)

--- a/src/main/java/gov/usds/case_issues/db/repositories/BulkCaseRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/BulkCaseRepository.java
@@ -12,11 +12,11 @@ import org.springframework.data.rest.core.annotation.RestResource;
  */
 public interface BulkCaseRepository {
 
-	@Query(name="snoozed")
+	@Query(name="snoozedFirstPage")
 	@RestResource(exported=false)
 	public List<Object[]> getSnoozedCases(Long caseManagementSystemId, Long caseTypeId, Integer size);
 
-	@Query(name="snoozedAfter")
+	@Query(name="snoozedLaterPage")
 	@RestResource(exported=false)
 	public List<Object[]> getSnoozedCasesAfter(
 		Long caseManagementSystemId,
@@ -27,7 +27,7 @@ public interface BulkCaseRepository {
 		Integer size
 	);
 
-	@Query(name="unSnoozed")
+	@Query(name="notCurrentlySnoozedFirstPage")
 	@RestResource(exported=false)
 	public List<Object[]> getActiveCases(
 		Long caseManagementSystemId,
@@ -35,7 +35,7 @@ public interface BulkCaseRepository {
 		Integer size
 	);
 
-	@Query(name="unSnoozedAfter")
+	@Query(name="notCurrentlySnoozedLaterPage")
 	@RestResource(exported=false)
 	public List<Object[]> getActiveCasesAfter(
 		Long caseManagementSystemId,

--- a/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
@@ -1,0 +1,175 @@
+package gov.usds.case_issues.services;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.model.CaseSummary;
+import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
+
+public class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
+
+	private static final String SYSTEM = "FAKEY";
+	private static final String CASE_TYPE = "McFAKEFAKE";
+	private static final String ISSUE_TYPE = "PAGING";
+	private static final String DEFAULT_SNOOZE_REASON = "TIREDNOW";
+	private static final ZonedDateTime START_DATE = ZonedDateTime.of(2000, 5, 21, 12, 0, 0, 0, ZoneId.of("GMT"));
+
+	private static final int PAGE_SIZE = 3;
+
+	private static final Logger LOG = LoggerFactory.getLogger(CaseListPagingFilteringTest.class);
+
+	@Autowired
+	private CaseListService _service;
+
+	private CaseManagementSystem _sys;
+	private CaseType _typ;
+
+	@SuppressWarnings("checkstyle:MagicNumber")
+	public enum FixtureCase {
+		/** An active case */
+		ACTIVE01(START_DATE),
+		/** A case that was opened and closed in the past */
+		CLOSED01(START_DATE.plusHours(24), START_DATE.plusHours(36)),
+		/** A case that is currently open and snoozed */
+		SNOOZED01(START_DATE.plusDays(1), DEFAULT_SNOOZE_REASON, 10, false),
+		/** A case that is currently open and was previously snoozed but is now active */
+		DESNOOZED01(START_DATE.plusDays(2), DEFAULT_SNOOZE_REASON, 10, true),
+		/** A case that was opened, snoozed, and closed without the snooze ending */
+		CLOSED02(START_DATE.plusDays(2), START_DATE.plusDays(3), DEFAULT_SNOOZE_REASON, 100, false),
+		/** An active case that is functionally identical to another active case ({@link #ACTIVE03}) */
+		ACTIVE02(START_DATE.plusDays(3)), // going to explore a paging issue with these
+		/** See {@link #ACTIVE02} */
+		ACTIVE03(START_DATE.plusDays(3)),
+		/** A snoozed case that was created later but snoozed for a shorter time than {@link #SNOOZED01} */
+		SNOOZED02(START_DATE, DEFAULT_SNOOZE_REASON, 5, false),
+		/** A desnoozed case that was created earlier but entered into the system later than {@link #DESNOOZED01} */
+		DESNOOZED02(START_DATE.plusDays(1), DEFAULT_SNOOZE_REASON, 10, true),
+		/** A snoozed case that is snoozed for a reasonably long time. */
+		SNOOZED03(START_DATE.plusDays(3), DEFAULT_SNOOZE_REASON, 20, false),
+		/** A snoozed case with a somewhat recent creation date and a moderate snooze length */
+		SNOOZED04(START_DATE.plusDays(5), DEFAULT_SNOOZE_REASON, 15, false),
+		/** A snoozed case with a much more recent creation date and a short snooze length */
+		SNOOZED05(START_DATE.plusDays(180), DEFAULT_SNOOZE_REASON, 1, false),
+		DESNOOZED03(START_DATE.plusDays(3), DEFAULT_SNOOZE_REASON, 5, true),
+		DESNOOZED04(START_DATE.plusDays(10), DEFAULT_SNOOZE_REASON, 5, true),
+		ACTIVE04(START_DATE.plusDays(2)),
+		ACTIVE05(START_DATE.plusDays(6)),
+		;
+
+		final ZonedDateTime startDate;
+		final ZonedDateTime endDate;
+		final String[] keyValues;
+		final String snoozeReason;
+		final int snoozeDays;
+		final boolean terminateSnooze;
+
+		private FixtureCase(ZonedDateTime startDate, String... keyValues) {
+			this(startDate, null, keyValues);
+		}
+
+		private FixtureCase(ZonedDateTime startDate, ZonedDateTime endDate, String... keyValues) {
+			this(startDate, endDate, null, 0, false, keyValues);
+		}
+
+		private FixtureCase(ZonedDateTime startDate, String snoozeReason, int snoozeDays, boolean cancelSnooze, String... keyValues) {
+			this(startDate, null, snoozeReason, snoozeDays, cancelSnooze, keyValues);
+		}
+
+		private FixtureCase(ZonedDateTime startDate, ZonedDateTime endDate, String snoozeReason, int snoozeDays, boolean cancelSnooze, String... keyValues) {
+			this.startDate = startDate;
+			this.keyValues = keyValues;
+			this.endDate = endDate;
+			this.snoozeReason = snoozeReason;
+			this.snoozeDays = snoozeDays;
+			this.terminateSnooze = cancelSnooze;
+		}
+	}
+
+	@Before
+	public void initPageableData() {
+		if (_dataService.checkForCaseManagementSystem(SYSTEM)) {
+			return;
+		}
+		LOG.info("Clearing DB, and initializing system and type");
+		this.truncateDb();
+		_sys = _dataService.ensureCaseManagementSystemInitialized(SYSTEM, "Fake Case Management System for paging/filtering test");
+		_typ = _dataService.ensureCaseTypeInitialized(CASE_TYPE, "Fake Case Type for paging/filtering test");
+		LOG.info("Initializing cases, issues and snoozes");
+		Stream.of(FixtureCase.values()).forEach(this::enumeratedCase);
+	}
+
+	private TroubleCase enumeratedCase(FixtureCase template) {
+		LOG.info("Initializing {} as a {} case", template, template.snoozeDays >  0 ? "snoozed" : "unsnoozed");
+		TroubleCase tc = _dataService.initCaseAndIssue(_sys,
+			template.name(),
+			_typ,
+			template.startDate,
+			ISSUE_TYPE,
+			template.endDate,
+			template.keyValues
+		);
+		if (template.snoozeReason != null) {
+			_dataService.snoozeCase(tc, template.snoozeReason, template.snoozeDays, template.terminateSnooze);
+		}
+		return tc;
+	}
+
+	@Test
+	public void getActiveCases_firstPage_correctResult() {
+		List<CaseSummary> activeCases = _service.getActiveCases(SYSTEM, CASE_TYPE, null, PAGE_SIZE);
+		assertEquals(PAGE_SIZE, activeCases.size());
+		assertCaseOrder(activeCases, FixtureCase.ACTIVE01, FixtureCase.DESNOOZED02, FixtureCase.DESNOOZED01);
+	}
+
+	@Test
+	public void getActiveCases_secondPage_correctResult() {
+		List<CaseSummary> foundCases = _service.getActiveCases(SYSTEM, CASE_TYPE, FixtureCase.DESNOOZED01.name(), PAGE_SIZE);
+		assertEquals(PAGE_SIZE, foundCases.size());
+		assertCaseOrder(foundCases, FixtureCase.ACTIVE04, FixtureCase.ACTIVE02, FixtureCase.ACTIVE03);
+	}
+
+	/** This test validates and documents a behavior of active-case sorting that we probably do not want to maintain
+	 * in the long run */
+	@Test
+	public void getActiveCases_interStitialPage_weirdBehaviorIsStable() {
+		List<CaseSummary> foundCases = _service.getActiveCases(SYSTEM, CASE_TYPE, FixtureCase.ACTIVE02.name(), PAGE_SIZE);
+		assertEquals(PAGE_SIZE, foundCases.size());
+		assertCaseOrder(foundCases, FixtureCase.ACTIVE03, FixtureCase.DESNOOZED03, FixtureCase.ACTIVE05);
+		foundCases = _service.getActiveCases(SYSTEM, CASE_TYPE, FixtureCase.ACTIVE03.name(), PAGE_SIZE);
+		assertEquals(PAGE_SIZE, foundCases.size());
+		assertCaseOrder(foundCases, FixtureCase.ACTIVE02, FixtureCase.DESNOOZED03, FixtureCase.ACTIVE05);
+	}
+
+	@Test
+	public void getSnoozedCases_fetchFirstPage_correctResult() {
+		List<CaseSummary> foundCases = _service.getSnoozedCases(SYSTEM, CASE_TYPE, null, PAGE_SIZE);
+		assertCaseOrder(foundCases, FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED01);
+
+	}
+
+	@Test
+	public void getSnoozedCases_fetchSecondPage_correctResult() {
+		List<CaseSummary> foundCases = _service.getSnoozedCases(SYSTEM, CASE_TYPE, FixtureCase.SNOOZED01.name(), PAGE_SIZE);
+		assertCaseOrder(foundCases, FixtureCase.SNOOZED04, FixtureCase.SNOOZED03);
+	}
+
+	private static void assertCaseOrder(List<CaseSummary> foundCases, FixtureCase... expected) {
+		List<String> foundReceipts = foundCases.stream().map(CaseSummary::getReceiptNumber).collect(Collectors.toList());
+		List<String> expectedReceipts = Stream.of(expected).map(FixtureCase::name).collect(Collectors.toList());
+		assertEquals(expectedReceipts, foundReceipts);
+	}
+}

--- a/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
@@ -161,6 +161,29 @@ public class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
 
 	}
 
+	@Test(expected=IllegalArgumentException.class)
+	public void getSnoozedCases_invalidPageActiveCase_exception() {
+		_service.getSnoozedCases(SYSTEM, CASE_TYPE, FixtureCase.ACTIVE01.name(), PAGE_SIZE);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void getSnoozedCases_invalidPageDeSnoozedCase_exception() {
+		_service.getSnoozedCases(SYSTEM, CASE_TYPE, FixtureCase.DESNOOZED01.name(), PAGE_SIZE);
+	}
+
+	@Test
+	public void getActiveCases_invalidPageInvalidReceipt_firstPageFirstPageReturned() {
+		List<CaseSummary> activeCases = _service.getActiveCases(SYSTEM, CASE_TYPE, "NOSUCHANIMAL", PAGE_SIZE);
+		assertCaseOrder(activeCases, FixtureCase.ACTIVE01, FixtureCase.DESNOOZED02, FixtureCase.DESNOOZED01);
+	}
+
+	@Test
+	public void getSnoozedCases_invalidPageInvalidReceipt_firstPageReturned() {
+		List<CaseSummary> foundCases = _service.getSnoozedCases(SYSTEM, CASE_TYPE, "NOSUCHANIMAL", PAGE_SIZE);
+		assertCaseOrder(foundCases, FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED01);
+
+	}
+
 	@Test
 	public void getSnoozedCases_fetchSecondPage_correctResult() {
 		List<CaseSummary> foundCases = _service.getSnoozedCases(SYSTEM, CASE_TYPE, FixtureCase.SNOOZED01.name(), PAGE_SIZE);

--- a/src/test/java/gov/usds/case_issues/services/CaseListServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseListServiceTest.java
@@ -346,6 +346,7 @@ public class CaseListServiceTest extends CaseIssueApiTestBase {
 		_service.getUploadFormat("INVALID DATE FORMAT");
 	}
 
+	// if this test breaks during a re-build of the paging feature, delete it and re-implement it in CaseListPagingFilteringTest
 	@Test
 	@SuppressWarnings("checkstyle:MagicNumber")
 	public void getActiveCases_addedNewestFirest_paginatedCorrectly() {


### PR DESCRIPTION
Preparatory to adding more features to our list fetches:
* refactored the bulk queries to be all concatenations of reusable constants
* removed legacy queries that we don't currently need
* added tests for all our existing paging behaviors, in a new test file suitable for testing more things like this
* changed one existing paging behavior that was trying to be relaxed but ended up being super weird and confusing