### PR TITLE
Removed annoying copyDeps task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,11 +82,6 @@ configurations {
 test.finalizedBy jacocoTestReport
 check.dependsOn jacocoTestCoverageVerification
 
-task copyDeps(type: Copy) {
-	from configurations.runtimeClasspath
-	into "${project.buildDir}/libs/"
-}
-
 springBoot {
 	buildInfo()
 }


### PR DESCRIPTION
To the extent that this functionality is needed, it can now be handled by agency-specific deploy/test infrastructure.