### PR TITLE
Filter on snooze reason

### DIFF
--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -37,6 +37,7 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 @DynamicUpdate
 @TypeDef(name="json", typeClass=JsonStringType.class)
 @NamedNativeQueries({
+	/* ALL SNOOZED CASES */
 	@NamedNativeQuery(
 		name = "snoozedFirstPage",
 		query = TroubleCase.CASE_SELECT_STEM
@@ -51,7 +52,7 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 				+ TroubleCase.CASE_CREATION_DATE_CONSTRAINT
 				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
-		),
+	),
 	@NamedNativeQuery(
 		name = "snoozedLaterPage",
 		query = TroubleCase.CASE_SELECT_STEM
@@ -69,6 +70,40 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
+	/* SNOOZED WITH SPECIFIC REASON */
+	@NamedNativeQuery(
+		name = "snoozeReasonFirstPage",
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_SPECIFIC_REASON_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
+		resultSetMapping="snoozeCaseMapping"
+	),
+	@NamedNativeQuery(
+		name = "snoozeReasonFirstPageDateFilter",
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_SPECIFIC_REASON_CONSTRAINT
+				+ TroubleCase.CASE_CREATION_DATE_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
+		resultSetMapping="snoozeCaseMapping"
+	),
+	@NamedNativeQuery(
+		name = "snoozeReasonLaterPage",
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_SPECIFIC_REASON_CONSTRAINT
+				+ TroubleCase.SNOOZED_PAGE_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
+		resultSetMapping="snoozeCaseMapping"
+	),
+	@NamedNativeQuery(
+		name = "snoozeReasonLaterPageDateFilter",
+		query = TroubleCase.CASE_SELECT_STEM
+				+ TroubleCase.SNOOZED_NOW_SPECIFIC_REASON_CONSTRAINT
+				+ TroubleCase.CASE_CREATION_DATE_CONSTRAINT
+				+ TroubleCase.SNOOZED_PAGE_CONSTRAINT
+				+ TroubleCase.SNOOZED_NOW_POSTAMBLE,
+		resultSetMapping="snoozeCaseMapping"
+	),
+	/* ALL NON-SNOOZED CASES */
 	@NamedNativeQuery(
 		name = "notCurrentlySnoozedFirstPage",
 		query = TroubleCase.CASE_SELECT_STEM
@@ -101,6 +136,7 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 				+ TroubleCase.NOT_SNOOZED_NOW_POSTAMBLE,
 		resultSetMapping="snoozeCaseMapping"
 	),
+	/* PREVIOUSLY BUT NOT CURRENTLY SNOOZED CASES */
 	@NamedNativeQuery(
 		name = "previouslySnoozedFirstPage",
 		query = TroubleCase.CASE_SELECT_STEM
@@ -170,6 +206,14 @@ public class TroubleCase extends UpdatableEntity {
 	public static final String NOT_SNOOZED_NOW_CONSTRAINT = " (last_snooze_end IS NULL OR last_snooze_end < CURRENT_TIMESTAMP) ";
 	public static final String SNOOZED_NOW_CONSTRAINT = " last_snooze_end >= CURRENT_TIMESTAMP ";
 	public static final String SNOOZED_PREVIOUSLY_CONSTRAINT = " last_snooze_end < CURRENT_TIMESTAMP ";
+	public static final String SNOOZED_NOW_SPECIFIC_REASON_CONSTRAINT =
+			" exists ("
+			+ "	SELECT *"
+			+ " FROM {h-schema}case_snooze s "
+			+ " WHERE s.snooze_case_internal_id = trouble_case_dto.internal_id "
+			+ " AND s.snooze_reason = :snoozeReason "
+			+ " AND s.snooze_end >= CURRENT_TIMESTAMP "
+			+ ") ";
 
 	public static final String CASE_CREATION_DATE_CONSTRAINT =
 		" AND case_creation BETWEEN :caseCreationWindowStart and :caseCreationWindowEnd "; // BETWEEN treats the endpoint values as included in the range.

--- a/src/main/java/gov/usds/case_issues/db/repositories/BulkCaseRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/BulkCaseRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PastOrPresent;
 
+import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RestResource;
@@ -34,6 +35,26 @@ public interface BulkCaseRepository {
 			@PastOrPresent @NotNull ZonedDateTime caseCreationWindowEnd,
 		    @Range(max=MAX_PAGE_SIZE) int size);
 
+	@Query(name="snoozeReasonFirstPage")
+	@RestResource(exported=false)
+	public List<Object[]> getSnoozedCases(
+		long caseManagementSystemId,
+		long caseTypeId,
+		@NotNull @Length(min=1) String snoozeReason,
+		@Range(max=MAX_PAGE_SIZE) int size
+	);
+
+	@Query(name="snoozeReasonFirstPageDateFilter")
+	@RestResource(exported=false)
+	public List<Object[]> getSnoozedCases(
+		long caseManagementSystemId,
+		long caseTypeId,
+		@PastOrPresent @NotNull ZonedDateTime caseCreationWindowStart,
+		@PastOrPresent @NotNull ZonedDateTime caseCreationWindowEnd,
+		@NotNull @Length(min=1) String snoozeReason,
+	    @Range(max=MAX_PAGE_SIZE) int size
+    );
+
 	@Query(name="snoozedLaterPage")
 	@RestResource(exported=false)
 	public List<Object[]> getSnoozedCasesAfter(
@@ -44,6 +65,19 @@ public interface BulkCaseRepository {
 		Long internalId,
 		@Range(max=MAX_PAGE_SIZE) int size
 	);
+
+	@Query(name="snoozeReasonLaterPage")
+	@RestResource(exported=false)
+	public List<Object[]> getSnoozedCasesAfter(
+		long caseManagementSystemId,
+		long caseTypeId,
+		ZonedDateTime lastSnoozeEnd,
+		ZonedDateTime caseCreation,
+		long internalId,
+		@NotNull @Length(min=1) String snoozeReason,
+		@Range(max=MAX_PAGE_SIZE) int size
+	);
+
 	@Query(name="snoozedLaterPageDateFilter")
 	@RestResource(exported=false)
 	public List<Object[]> getSnoozedCasesAfter(
@@ -56,6 +90,21 @@ public interface BulkCaseRepository {
 		@PastOrPresent @NotNull ZonedDateTime caseCreationWindowEnd,
 		@Range(max=MAX_PAGE_SIZE) int size
 	);
+
+	@Query(name="snoozeReasonLaterPageDateFilter")
+	@RestResource(exported=false)
+	public List<Object[]> getSnoozedCasesAfter(
+		Long caseManagementSystemId,
+		Long caseTypeId,
+		ZonedDateTime lastSnoozeEnd,
+		ZonedDateTime caseCreation,
+		Long internalId,
+		@PastOrPresent @NotNull ZonedDateTime caseCreationWindowStart,
+		@PastOrPresent @NotNull ZonedDateTime caseCreationWindowEnd,
+		@NotNull @Length(min=1) String snoozeReason,
+		@Range(max=MAX_PAGE_SIZE) int size
+	);
+
 	@Query(name="notCurrentlySnoozedFirstPage")
 	@RestResource(exported=false)
 	public List<Object[]> getActiveCases(

--- a/src/main/java/gov/usds/case_issues/services/CaseListService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseListService.java
@@ -162,7 +162,7 @@ public class CaseListService {
 			@TagFragment String receiptNumber, // wrong validation tag!
 			int size
 	) {
-		return getSnoozedCases(caseManagementSystemTag, caseTypeTag, receiptNumber, null, size);
+		return getSnoozedCases(caseManagementSystemTag, caseTypeTag, receiptNumber, null, Optional.empty(), size);
 	}
 
 	public List<CaseSummary> getSnoozedCases(
@@ -170,6 +170,7 @@ public class CaseListService {
 			@TagFragment String caseTypeTag,
 			@TagFragment String receiptNumber, // wrong validation tag!
 			DateRange caseCreationRange,
+			Optional<String> snoozeReason,
 			int size
 	) {
 		LOG.debug(
@@ -181,19 +182,39 @@ public class CaseListService {
 		List<Object[]> foundCases;
 		if (translated.isFirstPage()) {
 			if (caseCreationRange == null) {
-				foundCases = _bulkRepo.getSnoozedCases(
-					translated.getCaseManagementSystemId(),
-					translated.getCaseTypeId(),
-					size
-				);
+				if (snoozeReason.isPresent()) {
+					foundCases = _bulkRepo.getSnoozedCases(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						snoozeReason.get(),
+						size
+					);
+				} else {
+					foundCases = _bulkRepo.getSnoozedCases(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						size
+					);
+				}
 			} else {
-				foundCases = _bulkRepo.getSnoozedCases(
-					translated.getCaseManagementSystemId(),
-					translated.getCaseTypeId(),
-					caseCreationRange.getStartDate(),
-					caseCreationRange.getEndDate(),
-					size
-				);
+				if (snoozeReason.isPresent()) {
+					foundCases = _bulkRepo.getSnoozedCases(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						caseCreationRange.getStartDate(),
+						caseCreationRange.getEndDate(),
+						snoozeReason.get(),
+						size
+					);
+				} else {
+					foundCases = _bulkRepo.getSnoozedCases(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						caseCreationRange.getStartDate(),
+						caseCreationRange.getEndDate(),
+						size
+					);
+				}
 			}
 		} else {
 			TroubleCase troubleCase = translated.getCase();
@@ -210,25 +231,51 @@ public class CaseListService {
 				throw new IllegalArgumentException("Snooze was ended for this case before page request was sent.");
 			}
 			if (caseCreationRange == null) {
-				foundCases = _bulkRepo.getSnoozedCasesAfter(
-					translated.getCaseManagementSystemId(),
-					translated.getCaseTypeId(),
-					lastSnoozeEnd,
-					troubleCase.getCaseCreation(),
-					troubleCase.getInternalId(),
-					size
-				);
+				if (snoozeReason.isPresent()) {
+					foundCases = _bulkRepo.getSnoozedCasesAfter(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						lastSnoozeEnd,
+						troubleCase.getCaseCreation(),
+						troubleCase.getInternalId(),
+						snoozeReason.get(),
+						size
+					);
+				} else {
+					foundCases = _bulkRepo.getSnoozedCasesAfter(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						lastSnoozeEnd,
+						troubleCase.getCaseCreation(),
+						troubleCase.getInternalId(),
+						size
+					);
+				}
 			} else {
-				foundCases = _bulkRepo.getSnoozedCasesAfter(
-					translated.getCaseManagementSystemId(),
-					translated.getCaseTypeId(),
-					lastSnoozeEnd,
-					troubleCase.getCaseCreation(),
-					troubleCase.getInternalId(),
-					caseCreationRange.getStartDate(),
-					caseCreationRange.getEndDate(),
-					size
-				);
+				if (snoozeReason.isPresent()) {
+					foundCases = _bulkRepo.getSnoozedCasesAfter(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						lastSnoozeEnd,
+						troubleCase.getCaseCreation(),
+						troubleCase.getInternalId(),
+						caseCreationRange.getStartDate(),
+						caseCreationRange.getEndDate(),
+						snoozeReason.get(),
+						size
+					);
+				} else {
+					foundCases = _bulkRepo.getSnoozedCasesAfter(
+						translated.getCaseManagementSystemId(),
+						translated.getCaseTypeId(),
+						lastSnoozeEnd,
+						troubleCase.getCaseCreation(),
+						troubleCase.getInternalId(),
+						caseCreationRange.getStartDate(),
+						caseCreationRange.getEndDate(),
+						size
+					);
+				}
 			}
 		}
 		return rewrap(foundCases);


### PR DESCRIPTION
Added one more block to the Jenga tower of filter queries, to allow filtering the snoozed case list (and only the snoozed case list) on the reason for the current (and only the current) snooze.