### PR TITLE
Tweaked case list sorting for better stability/visibility.

### DIFF
--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -218,18 +218,24 @@ public class TroubleCase extends UpdatableEntity {
 	public static final String CASE_CREATION_DATE_CONSTRAINT =
 		" AND case_creation BETWEEN :caseCreationWindowStart and :caseCreationWindowEnd "; // BETWEEN treats the endpoint values as included in the range.
 
+
+	private static final String CREATION_TO_RECEIPT_FALLBACK =
+		" case_creation = :caseCreation AND receipt_number > "
+		+ " (select receipt_number from trouble_case where internal_id = :internalId)";
 	public static final String NOT_SNOOZED_NOW_PAGE_CONSTRAINT =
-		"  AND case_creation >= :caseCreation "
-		+ "AND internal_id != :internalId ";
+		" AND (case_creation > :caseCreation OR "
+		+ CREATION_TO_RECEIPT_FALLBACK
+		+") ";
 	public static final String SNOOZED_PAGE_CONSTRAINT =
 		"  AND (last_snooze_end > :lastSnoozeEnd"
-		+ "     OR (last_snooze_end = :lastSnoozeEnd AND case_creation >= :caseCreation) ) "
-		+ "AND internal_id != :internalId ";
+		+ " OR (last_snooze_end = :lastSnoozeEnd AND case_creation > :caseCreation) "
+		+ " OR (last_snooze_end = :lastSnoozeEnd AND " + CREATION_TO_RECEIPT_FALLBACK + ")"
+		+ ")";
 	public static final String NOT_SNOOZED_NOW_POSTAMBLE =
-		"  ORDER BY case_creation ASC, internal_id ASC "
+		"  ORDER BY case_creation ASC, receipt_number ASC "
 		+ "LIMIT :size";
 	public static final String SNOOZED_NOW_POSTAMBLE =
-		"  ORDER BY last_snooze_end ASC, case_creation ASC, internal_id ASC "
+		"  ORDER BY last_snooze_end ASC, case_creation ASC, receipt_number ASC "
 		+ "LIMIT :size";
 
 	public static final String CASE_DTO_CTE = "(" + CASE_DTO_QUERY + ") as trouble_case_dto ";

--- a/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
@@ -62,10 +62,11 @@ public class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
 		DESNOOZED01(START_DATE.plusDays(2), DEFAULT_SNOOZE_REASON, 10, true),
 		/** A case that was opened, snoozed, and closed without the snooze ending */
 		CLOSED02(START_DATE.plusDays(2).plusSeconds(1), START_DATE.plusDays(3), DEFAULT_SNOOZE_REASON, 100, false),
-		/** An active case that is functionally identical to another active case ({@link #ACTIVE03}) */
-		ACTIVE02(START_DATE.plusDays(3)), // going to explore a paging issue with these
+		// The following two case are reversed to create a conflict between alphabetical and insert-order sorting
 		/** See {@link #ACTIVE02} */
 		ACTIVE03(START_DATE.plusDays(3)), // intentional creation date collision
+		/** An active case that is functionally identical to another active case ({@link #ACTIVE03}) */
+		ACTIVE02(START_DATE.plusDays(3)), // going to explore a paging issue with these
 		/** A snoozed case that was created later but snoozed for a shorter time than {@link #SNOOZED01} */
 		SNOOZED02(START_DATE, ALTERNATE_SNOOZE_REASON, 5, false),
 		/** A desnoozed case that was created earlier but entered into the system later than {@link #DESNOOZED01} */
@@ -155,7 +156,7 @@ public class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
 	}
 
 	// exhaustively test paged requests for stability
-	@Test(expected=java.lang.AssertionError.class) // this fails because of the issue documented by the next test
+	@Test
 	public void getActiveCases_walkThroughCaseList_correctResults() {
 		int includeAllCases = FixtureCase.values().length;
 		List<FixtureCase> allFixtures = new ArrayList<>(Arrays.asList(
@@ -174,18 +175,6 @@ public class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
 			assertCaseOrder(message, allFixtures,
 				_service.getActiveCases(SYSTEM, CASE_TYPE, firstReceipt, includeAllCases));
 		}
-	}
-
-	/** This test validates and documents a behavior of active-case sorting that we probably do not want to maintain
-	 * in the long run */
-	@Test
-	public void getActiveCases_interStitialPage_weirdBehaviorIsStable() {
-		List<CaseSummary> foundCases = _service.getActiveCases(SYSTEM, CASE_TYPE, FixtureCase.ACTIVE02.name(), PAGE_SIZE);
-		assertEquals(PAGE_SIZE, foundCases.size());
-		assertCaseOrder(foundCases, FixtureCase.ACTIVE03, FixtureCase.DESNOOZED03, FixtureCase.ACTIVE05);
-		foundCases = _service.getActiveCases(SYSTEM, CASE_TYPE, FixtureCase.ACTIVE03.name(), PAGE_SIZE);
-		assertEquals(PAGE_SIZE, foundCases.size());
-		assertCaseOrder(foundCases, FixtureCase.ACTIVE02, FixtureCase.DESNOOZED03, FixtureCase.ACTIVE05);
 	}
 
 	@Test


### PR DESCRIPTION
Made case list repository sort on receipt number instead of internal_id so that we are not dependent on case insertion order, and re-did paging/sorting logic to guarantee fully non-overlapping pages.