### PR TITLE
User signatures followup

### DIFF
--- a/src/main/java/gov/usds/case_issues/config/DemoUserLoginConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/DemoUserLoginConfig.java
@@ -16,8 +16,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 import gov.usds.case_issues.controllers.UserInformationApiController;
-import gov.usds.case_issues.db.model.UserInformation;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.services.UserService;
 import springfox.documentation.service.ApiInfo;
 
 @Configuration
@@ -29,7 +28,7 @@ public class DemoUserLoginConfig {
 	@Autowired
 	private WebConfigurationProperties _webProperties;
 	@Autowired
-	UserRepository _userRepo;
+	private UserService _userInformationService;
 	@Autowired
 	private ApiInfo _apiInfo;
 
@@ -56,9 +55,7 @@ public class DemoUserLoginConfig {
 		LOG.info("Configuring demo users from {}.", _webProperties);
 		List<UserDetails> users = _webProperties.getUsers().stream()
 				.map(u -> {
-
-					UserInformation user = new UserInformation(u.getName(), u.getPrintName());
-					_userRepo.save(user);
+					_userInformationService.createUserOrUpdateLastSeen(u.getName(), u.getPrintName());
 
 					return User
 					.withUsername(u.getName())

--- a/src/main/java/gov/usds/case_issues/config/RestConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/RestConfig.java
@@ -5,15 +5,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.mapping.ExposureConfigurer.AggregateResourceHttpMethodsFilter;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.http.HttpMethod;
 
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
 import gov.usds.case_issues.db.model.TaggedEntity;
+import gov.usds.case_issues.db.model.UserInformation;
 import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
 import gov.usds.case_issues.db.repositories.CaseTypeRepository;
 import gov.usds.case_issues.db.repositories.AttachmentSubtypeRepository;
 import gov.usds.case_issues.db.repositories.TaggedEntityRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 
 @Configuration
 @ConditionalOnWebApplication
@@ -33,9 +37,19 @@ public class RestConfig implements RepositoryRestConfigurer {
 			.forRepository(AttachmentSubtypeRepository.class)
 				.withIdMapping(TaggedEntity::getExternalId)
 				.withLookup(TaggedEntityRepository::findByExternalId)
+			.forRepository(UserInformationRepository.class)
+				.withIdMapping(UserInformation::getId)
+				.withLookup(UserInformationRepository::findByUserId)
+		;
+
+		AggregateResourceHttpMethodsFilter noUnsafeMethods = (metadata, methods) ->
+			methods.disable(HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.PUT);
+		config.getExposureConfiguration()
+			.forDomainType(UserInformation.class)
+				.withItemExposure(noUnsafeMethods)
+				.withCollectionExposure(noUnsafeMethods)
 		;
 		LOG.info("Disabling CORS access to repository REST resources");
-
 		// this is very broad, but only applies when controllers managed by this configuration, so
 		// we can leave it broad instead of tailoring it to our actual URL configuration.
 		config.getCorsRegistry().addMapping("/**").allowedOrigins();

--- a/src/main/java/gov/usds/case_issues/db/model/UserInformation.java
+++ b/src/main/java/gov/usds/case_issues/db/model/UserInformation.java
@@ -5,12 +5,14 @@ import java.util.Date;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.NaturalId;
 
 /**
  * Metadata about the case issue data stored in this system
  */
 @Entity
+@DynamicUpdate
 public class UserInformation extends UpdatableEntity {
 
 	@NotNull
@@ -37,6 +39,10 @@ public class UserInformation extends UpdatableEntity {
 
 	public String getPrintName() {
 		return printName;
+	}
+
+	public void setPrintName(String newName) {
+		printName = newName;
 	}
 
 	public String getId() {

--- a/src/main/java/gov/usds/case_issues/db/repositories/UserInformationRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/UserInformationRepository.java
@@ -4,20 +4,32 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.Description;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 import gov.usds.case_issues.db.model.UserInformation;;
 
 
-public interface UserRepository extends CrudRepository<UserInformation, Long> {
+@RepositoryRestResource(
+	path="users",
+	itemResourceRel="user",
+	collectionResourceRel="users",
+	collectionResourceDescription=@Description("All users that have logged in at least once.")
+)
+public interface UserInformationRepository extends CrudRepository<UserInformation, Long> {
 
 	@Override
 	@CachePut(value="byUserId", key="#entity.getId()")
+	@RestResource(exported=false)
 	<S extends UserInformation> S save(S entity);
 
 	@Override
 	@CacheEvict(value="byUserId", key="#entity.getId()")
+	@RestResource(exported=false)
 	void delete(UserInformation entity);
 
 	@Cacheable(value="byUserId", key="#userId")
+	@RestResource(exported=false)
 	public UserInformation findByUserId(String userId);
 }

--- a/src/main/java/gov/usds/case_issues/db/repositories/UserInformationRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/UserInformationRepository.java
@@ -19,17 +19,19 @@ import gov.usds.case_issues.db.model.UserInformation;;
 )
 public interface UserInformationRepository extends CrudRepository<UserInformation, Long> {
 
+	public static final String USER_ID_CACHE = "byUserId";
+
 	@Override
-	@CachePut(value="byUserId", key="#entity.getId()")
+	@CachePut(value=USER_ID_CACHE, key="#entity.getId()")
 	@RestResource(exported=false)
 	<S extends UserInformation> S save(S entity);
 
 	@Override
-	@CacheEvict(value="byUserId", key="#entity.getId()")
+	@CacheEvict(value=USER_ID_CACHE, key="#entity.getId()")
 	@RestResource(exported=false)
 	void delete(UserInformation entity);
 
-	@Cacheable(value="byUserId", key="#userId")
+	@Cacheable(value=USER_ID_CACHE, key="#userId")
 	@RestResource(exported=false)
 	public UserInformation findByUserId(String userId);
 }

--- a/src/main/java/gov/usds/case_issues/services/CaseDetailsService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseDetailsService.java
@@ -21,7 +21,7 @@ import gov.usds.case_issues.db.repositories.CaseIssueRepository;
 import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
 import gov.usds.case_issues.db.repositories.CaseSnoozeRepository;
 import gov.usds.case_issues.db.repositories.TroubleCaseRepository;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 import gov.usds.case_issues.model.ApiModelNotFoundException;
 import gov.usds.case_issues.model.CaseDetails;
 import gov.usds.case_issues.model.CaseSnoozeSummaryFacade;
@@ -42,7 +42,7 @@ public class CaseDetailsService {
 	@Autowired
 	private TroubleCaseRepository _caseRepo;
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 	@Autowired
 	private CaseSnoozeRepository _snoozeRepo;
 	@Autowired

--- a/src/main/java/gov/usds/case_issues/services/UserService.java
+++ b/src/main/java/gov/usds/case_issues/services/UserService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gov.usds.case_issues.db.model.UserInformation;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 import gov.usds.case_issues.model.SerializedUserInformation;
 
 @Service
@@ -14,7 +14,7 @@ import gov.usds.case_issues.model.SerializedUserInformation;
 public class UserService {
 
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 
 	public SerializedUserInformation getCurrentUser(Authentication auth) {
 		String id = auth.getName();

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -398,3 +398,12 @@ databaseChangeLog:
             dbms: postgresql
             path: repair-createdby-updatedby.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: add-unique-user-constraint
+      author: ben.warfield@usds.dhs.gov
+      comment: Add unique constraint for the external user ID in user_information.
+      changes:
+        - addUniqueConstraint:
+            tableName: user_information
+            constraint_name: uk__user_information
+            columnNames: user_id

--- a/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
+++ b/src/test/java/gov/usds/case_issues/config/OAuthMappingConfigTest.java
@@ -29,7 +29,7 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 
 import gov.usds.case_issues.authorization.CaseIssuePermission;
 import gov.usds.case_issues.db.model.UserInformation;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 import gov.usds.case_issues.services.UserService;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
 
@@ -39,7 +39,7 @@ public class OAuthMappingConfigTest extends CaseIssueApiTestBase {
 	@Autowired
 	private UserService _userService;
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 
 	private static final List<String> NEVER_FOUND = Arrays.asList("no_such_attribute","nopenopenope");
 

--- a/src/test/java/gov/usds/case_issues/controllers/CaseDetailsApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/CaseDetailsApiControllerTest.java
@@ -30,7 +30,7 @@ import gov.usds.case_issues.db.model.AttachmentType;
 import gov.usds.case_issues.db.model.TroubleCase;
 import gov.usds.case_issues.db.model.UserInformation;
 import gov.usds.case_issues.db.repositories.AttachmentSubtypeRepository;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 import gov.usds.case_issues.model.AttachmentRequest;
 
 @WithMockUser(username = "d15f7835-7fe7-438d-b889-90a5f5974ec2", authorities = {"READ_CASES", "UPDATE_CASES"})
@@ -44,7 +44,7 @@ public class CaseDetailsApiControllerTest extends ControllerTestBase {
 	@Autowired
 	private AttachmentSubtypeRepository _subtypeRepository;
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 
 	@Before
 	public void resetDb() {

--- a/src/test/java/gov/usds/case_issues/controllers/OneShotControllersTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/OneShotControllersTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import gov.usds.case_issues.db.model.UserInformation;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 
 /**
  * Consolidated tests for the controllers that have one handler each and are too annoying.
@@ -22,7 +22,7 @@ import gov.usds.case_issues.db.repositories.UserRepository;
 public class OneShotControllersTest extends ControllerTestBase {
 
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 
 	@Before
 	public void resetDb() {

--- a/src/test/java/gov/usds/case_issues/services/UserServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/UserServiceTest.java
@@ -10,13 +10,13 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.usds.case_issues.db.model.UserInformation;
-import gov.usds.case_issues.db.repositories.UserRepository;
+import gov.usds.case_issues.db.repositories.UserInformationRepository;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
 
 public class UserServiceTest extends CaseIssueApiTestBase {
 
 	@Autowired
-	private UserRepository _userRepo;
+	private UserInformationRepository _userRepo;
 	@Autowired
 	private UserService _service;
 


### PR DESCRIPTION
* added UK constraint for users
* cleaned up REST endpoints (since we do not want to allow users to be modified through the resources API)
* made the demo user system not break when used with a non-embedded database
* minor associated nit-picks