### PR TITLE
Implemented cleaner and less sneaky conditional OAuth2 configuration.

### DIFF
--- a/src/main/java/gov/usds/case_issues/config/OAuth2ClientRegistrationCondition.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuth2ClientRegistrationCondition.java
@@ -1,0 +1,28 @@
+package gov.usds.case_issues.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition implementation to enable definition of beans that are only registered
+ * when there is an OAuth2 client registration in the configuration.
+ */
+public class OAuth2ClientRegistrationCondition extends SpringBootCondition {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OAuth2ClientRegistrationCondition.class);
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		boolean clientPropertiesFound = Binder.get(context.getEnvironment())
+			.bind("spring.security.oauth2.client", OAuth2ClientProperties.class)
+			.isBound();
+		LOG.debug("OAuth2 Client Registration condition result is {}", clientPropertiesFound);
+		return clientPropertiesFound ? ConditionOutcome.match() : ConditionOutcome.noMatch("No client properties found");
+	}
+}

--- a/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/OAuthMappingConfig.java
@@ -12,9 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
@@ -51,6 +51,7 @@ import gov.usds.case_issues.utils.HashUtils;
  */
 @Configuration
 @ConditionalOnWebApplication
+@Conditional(OAuth2ClientRegistrationCondition.class)
 public class OAuthMappingConfig {
 
 	private static final Logger LOG = LoggerFactory.getLogger(OAuthMappingConfig.class);
@@ -59,15 +60,10 @@ public class OAuthMappingConfig {
 	private UserService _userService;
 	@Autowired
 	private OAuth2CustomizationProperties mappedConfig;
-	@Autowired(required=false) //  this is a sneaky way of making the bean conditional: being less sneaky would be better
-	private OAuth2ClientProperties clientConfig;
 
 	@Bean
 	public WebSecurityPlugin oauthConfigurer() {
 		LOG.info("Preparing custom OAuth2 user service configuration");
-		if (clientConfig == null || clientConfig.getRegistration().isEmpty()) {
-			return null; // see above "sneaky" remark
-		}
 		final GrantedAuthoritiesMapper mapper = oauthAuthorityMapper(mappedConfig.getAuthorityPaths());
 		final OAuth2UserService<OAuth2UserRequest, OAuth2User> userService = createDelegatingUserService(
 				new DefaultOAuth2UserService(), mappedConfig.getNamePath(), _userService);


### PR DESCRIPTION
This has been sitting around untested in my local tree since September, since one of the workarounds did in fact work. Testing it took 15 minutes, and makes it significantly better, albeit at the cost of a little more code that our unit tests won't reach unless we get very creative.