### PR TITLE
Made authorization type-safe.

### DIFF
--- a/src/main/java/gov/usds/case_issues/authorization/RequireReadCasePermission.java
+++ b/src/main/java/gov/usds/case_issues/authorization/RequireReadCasePermission.java
@@ -1,0 +1,25 @@
+package gov.usds.case_issues.authorization;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Authorization annotation to specify that this method is only available to users with the
+ * permission to read case information fromthe system ({@link CaseIssuePermission#READ_CASES}).
+ */
+
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission)"
+		+ ".READ_CASES.name())")
+public @interface RequireReadCasePermission {
+
+}

--- a/src/main/java/gov/usds/case_issues/authorization/RequireUpdateCasePermission.java
+++ b/src/main/java/gov/usds/case_issues/authorization/RequireUpdateCasePermission.java
@@ -1,0 +1,24 @@
+package gov.usds.case_issues.authorization;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Authorization annotation to specify that this method is only available to users with the
+ * permission to update case and snooze information in the system ({@link CaseIssuePermission#UPDATE_CASES}).
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission)"
+		+ ".UPDATE_CASES.name())")
+public @interface RequireUpdateCasePermission {
+
+}

--- a/src/main/java/gov/usds/case_issues/authorization/RequireUploadPermission.java
+++ b/src/main/java/gov/usds/case_issues/authorization/RequireUploadPermission.java
@@ -1,0 +1,22 @@
+package gov.usds.case_issues.authorization;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Authorization annotation to specify that this method is only available to users with the
+ * permission to upload new issue lists to the system ({@link CaseIssuePermission#UPDATE_ISSUES}).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({METHOD, TYPE})
+@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission)"
+		+ ".UPDATE_ISSUES.name())")
+public @interface RequireUploadPermission {
+
+}

--- a/src/main/java/gov/usds/case_issues/controllers/CaseDetailsApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/CaseDetailsApiController.java
@@ -7,7 +7,6 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,16 +16,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import gov.usds.case_issues.authorization.RequireReadCasePermission;
+import gov.usds.case_issues.authorization.RequireUpdateCasePermission;
 import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
+import gov.usds.case_issues.model.AttachmentRequest;
 import gov.usds.case_issues.model.CaseDetails;
 import gov.usds.case_issues.model.CaseSnoozeSummaryFacade;
-import gov.usds.case_issues.model.AttachmentRequest;
 import gov.usds.case_issues.model.SnoozeRequest;
 import gov.usds.case_issues.services.CaseDetailsService;
 
 @RestController
 @RequestMapping("/api/caseDetails/{caseManagementSystemTag}/{receiptNumber}")
-@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).READ_CASES.name())")
+@RequireReadCasePermission
 public class CaseDetailsApiController {
 
 	@Autowired
@@ -48,7 +49,7 @@ public class CaseDetailsApiController {
 	}
 
 	@DeleteMapping("activeSnooze")
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_CASES.name())")
+	@RequireUpdateCasePermission
 	public ResponseEntity<Void> endActiveSnooze(@PathVariable String caseManagementSystemTag, @PathVariable String receiptNumber) {
 		// e-tag could be added here with the end-time of the snooze
 		if (_caseDetailsService.endActiveSnooze(caseManagementSystemTag, receiptNumber)) {
@@ -59,7 +60,7 @@ public class CaseDetailsApiController {
 	}
 
 	@PutMapping("activeSnooze")
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_CASES.name())")
+	@RequireUpdateCasePermission
 	public ResponseEntity<CaseSnoozeSummaryFacade> changeActiveSnooze(
 			@PathVariable String caseManagementSystemTag,
 			@PathVariable String receiptNumber,
@@ -69,6 +70,7 @@ public class CaseDetailsApiController {
 	}
 
 	@PostMapping("activeSnooze/notes")
+	@RequireUpdateCasePermission
 	public ResponseEntity<?> addNote(@PathVariable String caseManagementSystemTag,
 			@PathVariable String receiptNumber, @RequestBody AttachmentRequest newNote) {
 		_caseDetailsService.annotateActiveSnooze(caseManagementSystemTag, receiptNumber, newNote);

--- a/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
@@ -16,7 +16,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,6 +30,8 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
+import gov.usds.case_issues.authorization.RequireReadCasePermission;
+import gov.usds.case_issues.authorization.RequireUploadPermission;
 import gov.usds.case_issues.config.DataFormatSpec;
 import gov.usds.case_issues.db.model.TroubleCase;
 import gov.usds.case_issues.db.repositories.BulkCaseRepository;
@@ -44,7 +45,7 @@ import gov.usds.case_issues.services.IssueUploadService;
 import gov.usds.case_issues.validators.TagFragment;
 
 @RestController
-@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).READ_CASES.name())")
+@RequireReadCasePermission
 @RequestMapping("/api/cases/{caseManagementSystemTag}/{caseTypeTag}")
 @Validated
 public class HitlistApiController {
@@ -129,7 +130,7 @@ public class HitlistApiController {
 	}
 
 	@PutMapping(value="/{issueTag}",consumes= {"text/csv"})
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	@RequireUploadPermission
 	public ResponseEntity<?> updateIssueListCsv(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
 			@RequestBody InputStream csvStream, @RequestParam(required=false) String uploadSchema) throws IOException {
 		CaseGroupInfo translated = _listService.translatePath(caseManagementSystemTag, caseTypeTag);
@@ -143,7 +144,7 @@ public class HitlistApiController {
 		return ResponseEntity.accepted().build();
 	}
 
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	@RequireUploadPermission
 	@PutMapping(value="/{issueTag}",consumes= {MediaType.APPLICATION_JSON_VALUE})
 	public ResponseEntity<?> updateIssueListJson(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
 			@RequestBody List<Map<String,Object>> jsonData, @RequestParam(required=false) String uploadSchema) throws IOException {

--- a/src/main/java/gov/usds/case_issues/services/CaseListService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseListService.java
@@ -13,11 +13,11 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import gov.usds.case_issues.authorization.RequireUploadPermission;
 import gov.usds.case_issues.config.DataFormatSpec;
 import gov.usds.case_issues.config.WebConfigurationProperties;
 import gov.usds.case_issues.db.model.CaseIssue;
@@ -395,7 +395,7 @@ public class CaseListService {
 	 */
 
 	@Transactional(readOnly=false)
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	@RequireUploadPermission
 	public CaseIssueUpload putIssueList(CaseIssueUpload translated, List<CaseRequest> newIssueCases) {
 		// convenience aliases to local variables, for use in closures
 		final ZonedDateTime eventDate = translated.getEffectiveDate();

--- a/src/main/java/gov/usds/case_issues/services/IssueUploadService.java
+++ b/src/main/java/gov/usds/case_issues/services/IssueUploadService.java
@@ -6,9 +6,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import gov.usds.case_issues.authorization.RequireUploadPermission;
 import gov.usds.case_issues.db.model.CaseIssueUpload;
 import gov.usds.case_issues.model.CaseRequest;
 import gov.usds.case_issues.services.CaseListService.CaseGroupInfo;
@@ -24,7 +24,7 @@ public class IssueUploadService {
 	private CaseListService _listService;
 
 	@SuppressWarnings("checkstyle:IllegalCatch")
-	@PreAuthorize("hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())")
+	@RequireUploadPermission
 	public CaseIssueUpload putIssueList(CaseGroupInfo pathInfo, String issueTypeTag, List<CaseRequest> newIssueCases,
 			ZonedDateTime eventDate) {
 		CaseIssueUpload uploadStatus = _statusService.commenceUpload(


### PR DESCRIPTION
Added meta-annotations to replace the rampant use of @PreAuthorize in the service and controller layers.

Type organization here is up for discussion—might want to make a subpackage or a containing type? And might want to have them available for the other two authorities, even if they aren't used in annotations right now.