### PR TITLE
JSON type support

### DIFF
--- a/src/main/java/gov/usds/case_issues/db/JsonOperatorContributor.java
+++ b/src/main/java/gov/usds/case_issues/db/JsonOperatorContributor.java
@@ -1,0 +1,22 @@
+package gov.usds.case_issues.db;
+
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.function.SQLFunctionTemplate;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * A mix-in class to add Hibernate support for "functions" that are actually wrappers around
+ * postgresql's non-standard operators for JSON fields (e.g. <code>@></code>).
+ */
+public class JsonOperatorContributor implements MetadataBuilderContributor {
+
+	/** Wrapper function for <code>@></code>: returns true if the first argument contains the second argument. */
+	public static final String JSON_CONTAINS = "json_contains";
+
+	@Override
+	public void contribute(MetadataBuilder metadataBuilder) {
+		metadataBuilder.applySqlFunction(JSON_CONTAINS,
+			new SQLFunctionTemplate(StandardBasicTypes.BOOLEAN, "(?1 @> ?2::jsonb)"));
+	}
+}

--- a/src/main/java/gov/usds/case_issues/db/model/package-info.java
+++ b/src/main/java/gov/usds/case_issues/db/model/package-info.java
@@ -1,4 +1,14 @@
 /**
  * Hibernate/JPA models.
  */
+@TypeDefs({
+	@TypeDef(defaultForType=Map.class, typeClass=JsonBinaryType.class, name="jsonb"),
+})
 package gov.usds.case_issues.db.model;
+
+import java.util.Map;
+
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
       hibernate:
         format_sql: false
         generate_statistics: off
+        metadata_builder_contributor: gov.usds.case_issues.db.JsonOperatorContributor
         jdbc:
           lob:
             non_contextual_creation: true


### PR DESCRIPTION
Minor utility work required to fully support postgresql native JSON types in Hibernate.

* importing the JSON type and telling it to assume that's what we're using for `Map` fields on managed entities
* defining a custom "function" that actually represents a wrapper around postgresql's custom operator for JSON object inclusion (this is likely to be expanded as we do more things with JSON)