### PR TITLE
List Query Rebuild

### DIFF
--- a/src/main/java/gov/usds/case_issues/config/RestConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/RestConfig.java
@@ -13,6 +13,7 @@ import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
 import gov.usds.case_issues.db.model.TaggedEntity;
 import gov.usds.case_issues.db.model.UserInformation;
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
 import gov.usds.case_issues.db.repositories.CaseManagementSystemRepository;
 import gov.usds.case_issues.db.repositories.CaseTypeRepository;
 import gov.usds.case_issues.db.repositories.AttachmentSubtypeRepository;
@@ -44,11 +45,14 @@ public class RestConfig implements RepositoryRestConfigurer {
 
 		AggregateResourceHttpMethodsFilter noUnsafeMethods = (metadata, methods) ->
 			methods.disable(HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.PUT);
-		config.getExposureConfiguration()
-			.forDomainType(UserInformation.class)
-				.withItemExposure(noUnsafeMethods)
-				.withCollectionExposure(noUnsafeMethods)
-		;
+		config.getExposureConfiguration().forDomainType(UserInformation.class)
+			.withItemExposure(noUnsafeMethods)
+			.withCollectionExposure(noUnsafeMethods)
+			;
+		config.getExposureConfiguration().forDomainType(FilterableCase.class)
+			.withItemExposure(noUnsafeMethods)
+			.withCollectionExposure(noUnsafeMethods)
+			;
 		LOG.info("Disabling CORS access to repository REST resources");
 		// this is very broad, but only applies when controllers managed by this configuration, so
 		// we can leave it broad instead of tailoring it to our actual URL configuration.

--- a/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
@@ -5,18 +5,25 @@ import java.io.InputStream;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.hibernate.validator.constraints.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,8 +41,10 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import gov.usds.case_issues.authorization.RequireReadCasePermission;
 import gov.usds.case_issues.authorization.RequireUploadPermission;
 import gov.usds.case_issues.config.DataFormatSpec;
+import gov.usds.case_issues.db.model.AttachmentType;
 import gov.usds.case_issues.db.model.TroubleCase;
 import gov.usds.case_issues.db.repositories.BulkCaseRepository;
+import gov.usds.case_issues.model.AttachmentRequest;
 import gov.usds.case_issues.model.CaseRequest;
 import gov.usds.case_issues.model.CaseSnoozeFilter;
 import gov.usds.case_issues.model.CaseSummary;
@@ -46,6 +55,7 @@ import gov.usds.case_issues.services.FilterFactory;
 import gov.usds.case_issues.services.IssueUploadService;
 import gov.usds.case_issues.services.model.CaseFilter;
 import gov.usds.case_issues.services.model.CaseGroupInfo;
+import gov.usds.case_issues.validators.FilterParameter;
 import gov.usds.case_issues.validators.TagFragment;
 
 @RestController
@@ -53,6 +63,10 @@ import gov.usds.case_issues.validators.TagFragment;
 @RequestMapping("/api/cases/{caseManagementSystemTag}/{caseTypeTag}")
 @Validated
 public class HitlistApiController {
+
+	private static final Pattern FILTER_PATTERN = Pattern.compile("filter_(\\w+)(?:\\[(\\w+)\\])?");
+
+	private static final Logger LOG = LoggerFactory.getLogger(HitlistApiController.class);
 
 	@Autowired
 	private CaseListService _listService;
@@ -78,7 +92,8 @@ public class HitlistApiController {
 			@RequestParam(required=false) @DateTimeFormat(iso=ISO.DATE_TIME) ZonedDateTime caseCreationRangeEnd,
 			@RequestParam Optional<String> pageReference,
 			@RequestParam Optional<String> snoozeReason,
-			@RequestParam(defaultValue = "20") @Range(max=BulkCaseRepository.MAX_PAGE_SIZE) int size
+			@RequestParam(defaultValue = "20") @Range(max=BulkCaseRepository.MAX_PAGE_SIZE) int size,
+			@RequestParam MultiValueMap<@FilterParameter String, String> allParams
 			) {
 		if (snoozeReason.isPresent() && !mainFilter.contains(CaseSnoozeFilter.SNOOZED)) {
 			throw new IllegalArgumentException("Snooze reason cannot be specified for cases that are not snoozed");
@@ -88,7 +103,63 @@ public class HitlistApiController {
 			filters.add(FilterFactory.dateRange(new DateRange(caseCreationRangeBegin, caseCreationRangeEnd)));
 		}
 		snoozeReason.ifPresent(reason -> filters.add(FilterFactory.snoozeReason(reason)));
+		LOG.debug("All Parameters dict has size {} and keys {}", allParams.size(), allParams.keySet());
+		for (Entry<String, List<String>> e : allParams.entrySet()) {
+			String parameterName = e.getKey();
+			Matcher nameMatch = FILTER_PATTERN.matcher(parameterName);
+			if (nameMatch.matches()) {
+				LOG.debug("Filtering on entry {}", e);
+				List<String> parameterValue = e.getValue();
+				String firstValue = parameterValue.get(0);
+				String parameterRoot = nameMatch.group(1);
+				String subParameter = nameMatch.group(2);
+				switch(parameterRoot) {
+					case "hasLinkType":
+						LOG.debug("Looking for any link with subtype {}", firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.LINK, null, firstValue)));
+						break;
+					case "hasLink":
+						assertSubparameter(parameterRoot, subParameter);
+						LOG.debug("Looking for link with subtype {} and value {}", subParameter, firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.LINK, firstValue, subParameter)));
+						break;
+					case "hasTagType":
+						LOG.debug("Looking for any tag with subtype {}", firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.TAG, null, firstValue)));
+						break;
+					case "hasTag":
+						assertSubparameter(parameterRoot, subParameter);
+						LOG.debug("Looking for tag with subtype {} and value {}", subParameter, firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.TAG, firstValue, subParameter)));
+						break;
+					case "hasAnyComment":
+						LOG.debug("Looking for any comment");
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.COMMENT, null)));
+						break;
+					case "hasComment":
+						LOG.debug("Looking for a comment with text [{}]", firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.COMMENT, firstValue)));
+						break;
+					case "dataField":
+						LOG.debug("Filtering on a single data field");
+						assertSubparameter(parameterRoot, subParameter);
+						filters.add(FilterFactory.caseExtraData(Collections.singletonMap(subParameter, firstValue)));
+						break;
+					default:
+						throw new IllegalArgumentException(String.format("Invalid filter parameter %s", parameterName));
+				}
+			} else {
+				LOG.debug("Parameter {} skipped as non-matching", parameterName);
+			}
+		}
+		LOG.debug("Derived filter list: {}", filters);
 		return _filteringService.getCases(caseManagementSystemTag, caseTypeTag, mainFilter, size, Optional.empty(), pageReference, filters);
+	}
+
+	private static void assertSubparameter(String parameter, String subParameter) {
+		if (null == subParameter || subParameter.isEmpty()) {
+			throw new IllegalArgumentException("Parameter " + parameter + " requires a sub-parameter");
+		}
 	}
 
 	@GetMapping("snoozed")

--- a/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
@@ -179,7 +179,8 @@ public class HitlistApiController {
 						break;
 					case FilterParams.COMMENT_ANY:
 						LOG.debug("Looking for any comment");
-						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.COMMENT, null)));
+						boolean yesNo = Boolean.parseBoolean(firstValue);
+						filters.add(FilterFactory.hasAttachment(new AttachmentRequest(AttachmentType.COMMENT, null), yesNo));
 						break;
 					case FilterParams.COMMENT_CONTENT:
 						LOG.debug("Looking for a comment with text [{}]", firstValue);

--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCase.java
@@ -9,8 +9,6 @@ import javax.persistence.Column;
 import javax.persistence.ColumnResult;
 import javax.persistence.Entity;
 import javax.persistence.EntityResult;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.NamedNativeQueries;
 import javax.persistence.NamedNativeQuery;
 import javax.persistence.OneToMany;
@@ -20,7 +18,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.Where;
@@ -183,7 +180,7 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 		columns=@ColumnResult(name="last_snooze_end", type=ZonedDateTime.class)
 	),
 })
-public class TroubleCase extends UpdatableEntity {
+public class TroubleCase extends TroubleCaseFixedData {
 
 	public static final String CASE_SNOOZE_DECODE =
 		"case when last_snooze_end is null then 'NEVER_SNOOZED' "
@@ -241,22 +238,6 @@ public class TroubleCase extends UpdatableEntity {
 	public static final String CASE_DTO_CTE = "(" + CASE_DTO_QUERY + ") as trouble_case_dto ";
 	public static final String CASE_SELECT_STEM = "SELECT * FROM" + CASE_DTO_CTE + " WHERE ";
 
-	@NaturalId
-	@ManyToOne(optional=false)
-	@JoinColumn(updatable=false)
-	private CaseManagementSystem caseManagementSystem;
-	@NaturalId
-	@NotNull
-	@Pattern(regexp="[-\\w]+")
-	@Column(updatable=false)
-	private String receiptNumber;
-
-	@ManyToOne(optional=false)
-	@JoinColumn(nullable=false, updatable=false)
-	private CaseType caseType;
-	@NotNull
-	private ZonedDateTime caseCreation;
-
 	@OneToMany(mappedBy = "issueCase")
 	@Where(clause="issue_closed is null")
 	private List<CaseIssue> openIssues;
@@ -271,30 +252,10 @@ public class TroubleCase extends UpdatableEntity {
 			@NotNull @Pattern(regexp = "[-\\w]+") String receiptNumber, CaseType caseType,
 			@NotNull ZonedDateTime caseCreation,
 			Map<String,Object> extraData) {
-		this();
-		this.caseManagementSystem = caseManagementSystem;
-		this.receiptNumber = receiptNumber;
-		this.caseType = caseType;
-		this.caseCreation = caseCreation;
+		super(caseManagementSystem, receiptNumber, caseType, caseCreation);
 		this.extraData = new HashMap<String, Object>(extraData); // shallow copy for reasonable safety
 	}
 
-
-	public CaseManagementSystem getCaseManagementSystem() {
-		return caseManagementSystem;
-	}
-
-	public String getReceiptNumber() {
-		return receiptNumber;
-	}
-
-	public CaseType getCaseType() {
-		return caseType;
-	}
-
-	public ZonedDateTime getCaseCreation() {
-		return caseCreation;
-	}
 
 	@JsonIgnore
 	public List<CaseIssue> getOpenIssues() {

--- a/src/main/java/gov/usds/case_issues/db/model/TroubleCaseFixedData.java
+++ b/src/main/java/gov/usds/case_issues/db/model/TroubleCaseFixedData.java
@@ -1,0 +1,67 @@
+package gov.usds.case_issues.db.model;
+
+import java.time.ZonedDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.annotations.NaturalId;
+
+/**
+ * A base class containing only the scalar invariant fields of a trouble case.
+ */
+@MappedSuperclass
+public abstract class TroubleCaseFixedData extends UpdatableEntity {
+
+	@NaturalId
+	@ManyToOne(optional = false)
+	@JoinColumn(updatable = false, nullable = false)
+	private CaseManagementSystem caseManagementSystem;
+	@NaturalId
+	@NotNull
+	@Pattern(regexp = "[-\\w]+")
+	@Column(updatable = false, nullable = false)
+	private String receiptNumber;
+	@ManyToOne(optional = false)
+	@NotNull
+	@JoinColumn(updatable = false, nullable = false)
+	private CaseType caseType;
+	@NotNull
+	@Column(updatable = false, nullable = false)
+	private ZonedDateTime caseCreation;
+
+	protected TroubleCaseFixedData() { /* needed for hibernate/JPA */ }
+
+	protected TroubleCaseFixedData(
+			@NotNull CaseManagementSystem caseManagementSystem,
+			@NotNull @Pattern(regexp = "[-\\w]+") String receiptNumber,
+			@NotNull CaseType caseType,
+			@NotNull ZonedDateTime caseCreation) {
+		this();
+		this.caseManagementSystem = caseManagementSystem;
+		this.receiptNumber = receiptNumber;
+		this.caseType = caseType;
+		this.caseCreation = caseCreation;
+	}
+
+	public CaseManagementSystem getCaseManagementSystem() {
+		return caseManagementSystem;
+	}
+
+	public String getReceiptNumber() {
+		return receiptNumber;
+	}
+
+	public CaseType getCaseType() {
+		return caseType;
+	}
+
+	public ZonedDateTime getCaseCreation() {
+		return caseCreation;
+	}
+
+}

--- a/src/main/java/gov/usds/case_issues/db/model/reporting/FilterableCase.java
+++ b/src/main/java/gov/usds/case_issues/db/model/reporting/FilterableCase.java
@@ -1,0 +1,49 @@
+package gov.usds.case_issues.db.model.reporting;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Immutable;
+
+import gov.usds.case_issues.db.model.TroubleCaseFixedData;
+
+@Entity
+@Table(name="filterable_case_view")
+@Immutable
+public class FilterableCase extends TroubleCaseFixedData {
+
+    @Column(name="extra_data_converted")
+    private Map<String, Object> extraData;
+
+    // snooze embeds
+    private String snoozeReason;
+    private ZonedDateTime snoozeStart;
+    private ZonedDateTime snoozeEnd;
+
+    // state
+    private boolean hasOpenIssue;
+
+	public Map<String, Object> getExtraData() {
+		return extraData;
+	}
+
+	public String getSnoozeReason() {
+		return snoozeReason;
+	}
+
+	public ZonedDateTime getSnoozeStart() {
+		return snoozeStart;
+	}
+
+	public ZonedDateTime getSnoozeEnd() {
+		return snoozeEnd;
+	}
+
+	public boolean isHasOpenIssue() {
+		return hasOpenIssue;
+	}
+}

--- a/src/main/java/gov/usds/case_issues/db/repositories/AttachmentAssociationRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/AttachmentAssociationRepository.java
@@ -12,4 +12,7 @@ public interface AttachmentAssociationRepository extends CrudRepository<CaseAtta
 
 	@EntityGraph(attributePaths="attachment")
 	public List<CaseAttachmentAssociation> findAllBySnoozeSnoozeCaseOrderByUpdatedAtAsc(TroubleCase rootCase);
+
+	@EntityGraph(attributePaths={"attachment", "snooze.snoozeCase"})
+	public List<CaseAttachmentAssociation> findAllBySnoozeSnoozeCaseInternalIdIn(List<Long> caseIds);
 }

--- a/src/main/java/gov/usds/case_issues/db/repositories/TroubleCaseFixedDataRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/TroubleCaseFixedDataRepository.java
@@ -1,0 +1,36 @@
+package gov.usds.case_issues.db.repositories;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.LockModeType;
+import javax.validation.constraints.Size;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.TroubleCaseFixedData;
+
+@NoRepositoryBean
+public interface TroubleCaseFixedDataRepository<T extends TroubleCaseFixedData> extends Repository<T, Long>{
+
+	public static final int MAX_INLIST_SIZE = 32000;
+	public static final String INLIST_SIZE_MESSAGE = "Too many items in this IN-list: not all databases can handle this many placeholders.";
+
+	public Page<T> getAllByCaseManagementSystemAndCaseType(CaseManagementSystem caseManager, CaseType caseType, Pageable pageable);
+
+	public Optional<T> findByCaseManagementSystemAndReceiptNumber(CaseManagementSystem caseManager, String receiptNumber);
+
+	public List<T> getFirst5ByCaseManagementSystemAndCaseTypeAndReceiptNumberContains(CaseManagementSystem caseManager, CaseType caseType, String receiptNumber);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE) // might need to be more aggressive when postgresql table-level LOCK is available
+	public Collection<T> getAllByCaseManagementSystemAndReceiptNumberIn(CaseManagementSystem caseManager,
+			@Size(max=MAX_INLIST_SIZE, message=INLIST_SIZE_MESSAGE) Collection<String> receiptNumbers);
+
+}

--- a/src/main/java/gov/usds/case_issues/db/repositories/TroubleCaseRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/TroubleCaseRepository.java
@@ -1,16 +1,10 @@
 package gov.usds.case_issues.db.repositories;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import javax.persistence.LockModeType;
-import javax.validation.constraints.Size;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.Description;
@@ -28,23 +22,13 @@ import gov.usds.case_issues.db.model.TroubleCase;
 	collectionResourceDescription=@Description("All cases that have had at least one issue reported.")
 )
 @Validated
-public interface TroubleCaseRepository extends PagingAndSortingRepository<TroubleCase, Long>, BulkCaseRepository {
+public interface TroubleCaseRepository extends TroubleCaseFixedDataRepository<TroubleCase>, 
+	PagingAndSortingRepository<TroubleCase, Long>,
+	BulkCaseRepository {
 
 	public static final String ACTIVE_CASE_CLAUSE = "c.caseManagementSystem = :caseManagementSystem and c.caseType = :caseType and c.openIssues is not empty";
 	public static final String ACTIVE_CASE_QUERY = "select c from #{#entityName} c where " + ACTIVE_CASE_CLAUSE;
 	public static final String ACTIVE_SNOOZE_CLAUSE = "exists (select snoozeEnd from CaseSnooze where snoozeCase = c and snoozeEnd > CURRENT_TIMESTAMP)";
-	public static final int MAX_INLIST_SIZE = 32000;
-	public static final String INLIST_SIZE_MESSAGE = "Too many items in this IN-list: not all databases can handle this many placeholders.";
-
-	public List<TroubleCase> getFirst5ByCaseManagementSystemAndCaseTypeAndReceiptNumberContains(CaseManagementSystem caseManager, CaseType caseType, String receiptNumber);
-
-	public Page<TroubleCase> getAllByCaseManagementSystemAndCaseType(CaseManagementSystem caseManager, CaseType caseType, Pageable pageable);
-
-	public Optional<TroubleCase> findByCaseManagementSystemAndReceiptNumber(CaseManagementSystem caseManager, String receiptNumber);
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE) // might need to be more aggressive when postgresql table-level LOCK is available
-	public Collection<TroubleCase> getAllByCaseManagementSystemAndReceiptNumberIn(CaseManagementSystem caseManager,
-			@Size(max=MAX_INLIST_SIZE, message=INLIST_SIZE_MESSAGE) Collection<String> receiptNumbers);
 
 	@Query(ACTIVE_CASE_QUERY)
 	public Page<TroubleCase> getWithOpenIssues(CaseManagementSystem caseManagementSystem, CaseType caseType, Pageable pageable);

--- a/src/main/java/gov/usds/case_issues/db/repositories/reporting/FilterableCaseRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/reporting/FilterableCaseRepository.java
@@ -1,0 +1,11 @@
+package gov.usds.case_issues.db.repositories.reporting;
+
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
+import gov.usds.case_issues.db.repositories.TroubleCaseFixedDataRepository;
+
+/**
+ * Specialization of {@link TroubleCaseFixedDataRepository} for {@link FilterableCase} retrieval.
+ */
+public interface FilterableCaseRepository extends TroubleCaseFixedDataRepository<FilterableCase> {
+
+}

--- a/src/main/java/gov/usds/case_issues/db/repositories/reporting/FilterableCaseRepository.java
+++ b/src/main/java/gov/usds/case_issues/db/repositories/reporting/FilterableCaseRepository.java
@@ -1,5 +1,13 @@
 package gov.usds.case_issues.db.repositories.reporting;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
 import gov.usds.case_issues.db.model.reporting.FilterableCase;
 import gov.usds.case_issues.db.repositories.TroubleCaseFixedDataRepository;
 
@@ -8,4 +16,13 @@ import gov.usds.case_issues.db.repositories.TroubleCaseFixedDataRepository;
  */
 public interface FilterableCaseRepository extends TroubleCaseFixedDataRepository<FilterableCase> {
 
+	Slice<FilterableCase> findAll(Specification<FilterableCase> spec, Pageable pageable);
+
+	Optional<FilterableCase> findOne(Specification<FilterableCase> spec);
+
+	List<FilterableCase> findAll(Specification<FilterableCase> spec);
+
+	List<FilterableCase> findAll(Specification<FilterableCase> spec, Sort sort);
+
+	long count(Specification<FilterableCase> spec);
 }

--- a/src/main/java/gov/usds/case_issues/services/CaseFilteringService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseFilteringService.java
@@ -1,0 +1,312 @@
+package gov.usds.case_issues.services;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import javax.validation.constraints.NotNull;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import gov.usds.case_issues.db.JsonOperatorContributor;
+import gov.usds.case_issues.db.model.CaseAttachment;
+import gov.usds.case_issues.db.model.CaseAttachmentAssociation;
+import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
+import gov.usds.case_issues.db.repositories.AttachmentAssociationRepository;
+import gov.usds.case_issues.db.repositories.reporting.FilterableCaseRepository;
+import gov.usds.case_issues.model.AttachmentRequest;
+import gov.usds.case_issues.model.AttachmentSummary;
+import gov.usds.case_issues.model.CaseSnoozeFilter;
+import gov.usds.case_issues.model.CaseSummary;
+import gov.usds.case_issues.model.DateRange;
+import gov.usds.case_issues.services.model.CasePageInfo;
+
+@Service
+public class CaseFilteringService implements CasePagingService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CaseFilteringService.class);
+
+	private static final Sort DEFAULT_SORT = Sort.by(
+			Order.asc("caseCreation"), Order.asc("receiptNumber"));
+	private static final Sort SNOOZE_SORT = Sort.by(
+		Order.asc("snoozeEnd"), Order.asc("caseCreation"), Order.asc("receiptNumber"));
+
+	@Autowired
+	private FilterableCaseRepository _repo;
+	@Autowired
+	private AttachmentAssociationRepository _attachmentAssociationRepo;
+	@Autowired
+	private PageTranslationService _translator;
+
+	@Override
+	public List<? extends CaseSummary> getActiveCases(String caseManagementSystemTag, String caseTypeTag,
+			String receiptNumber, DateRange caseCreationRange, int size) {
+		return getCases(CaseSnoozeFilter.ACTIVE, caseManagementSystemTag, caseTypeTag, DEFAULT_SORT, Optional.ofNullable(receiptNumber), size, Optional.ofNullable(caseCreationRange),
+				Optional.empty(), Collections.emptyMap(), Optional.empty());
+	}
+
+	@Override
+	public List<? extends CaseSummary> getSnoozedCases(String caseManagementSystemTag, String caseTypeTag,
+			String receiptNumber, DateRange caseCreationRange, Optional<String> snoozeReason, int size) {
+		return getCases(CaseSnoozeFilter.SNOOZED, caseManagementSystemTag, caseTypeTag, SNOOZE_SORT, Optional.ofNullable(receiptNumber), size,
+				Optional.ofNullable(caseCreationRange),
+				snoozeReason, Collections.emptyMap(), Optional.empty());
+	}
+
+	@Override
+	public List<? extends CaseSummary> getPreviouslySnoozedCases(String caseManagementSystemTag, String caseTypeTag,
+			String receiptNumber, DateRange caseCreationRange, int size) {
+		return getCases(CaseSnoozeFilter.ALARMED, caseManagementSystemTag, caseTypeTag, DEFAULT_SORT, Optional.ofNullable(receiptNumber), size,
+				Optional.ofNullable(caseCreationRange),
+				Optional.empty(), Collections.emptyMap(), Optional.empty());
+	}
+
+	public List<CaseSummary> getCases(CaseSnoozeFilter queryFilter, String caseManagementSystemTag, String caseTypeTag, 
+			Sort sortOrder, Optional<String> pageReference, int pageSize,
+			@NotNull Optional<DateRange> caseCreationRange,
+			@NotNull Optional<String> snoozeReason,
+			@NotNull Map<String, Object> fieldFilter,
+			@NotNull Optional<AttachmentRequest> attachmentFilter
+			) {
+		if (sortOrder == null) {
+			sortOrder = DEFAULT_SORT;
+		}
+		Specification<FilterableCase> mainSpec = commonSpec(caseManagementSystemTag, caseTypeTag, sortOrder,
+				pageReference, caseCreationRange);
+		if (queryFilter != null) {
+			mainSpec = mainSpec.and(caseCategorySpec(queryFilter));
+		}
+		if (snoozeReason.isPresent()) {
+			mainSpec = mainSpec.and((root, query, cb) -> cb.equal(root.get("snoozeReason"), snoozeReason.get()));
+		}
+		if (fieldFilter != null && fieldFilter.size() > 0) {
+			mainSpec = mainSpec.and(caseExtraDataSpec(fieldFilter));
+		}
+		if (attachmentFilter.isPresent()) {
+			mainSpec = mainSpec.and(attachmentSpec(attachmentFilter.get()));
+		}
+		return wrapFetched(mainSpec, PageRequest.of(0, pageSize, sortOrder));
+	}
+
+	private Specification<FilterableCase> attachmentSpec(AttachmentRequest attachmentRequest) {
+		return (root, query, cb) -> {
+			Subquery<CaseAttachmentAssociation> sq = query.subquery(CaseAttachmentAssociation.class);
+			List<Predicate> conjunction = new ArrayList<>();
+			Root<CaseAttachmentAssociation> aRoot = sq.from(CaseAttachmentAssociation.class);
+			sq.select(aRoot);
+			Path<CaseAttachment> aPath = aRoot.get("attachment");
+			conjunction.add(cb.equal(aPath.get("attachmentType"), cb.literal(attachmentRequest.getNoteType())));
+			if (attachmentRequest.getSubtype() != null) {
+				conjunction.add(cb.equal(aPath.get("attachmentSubtype").get("externalId"), cb.literal(attachmentRequest.getSubtype())));
+			}
+			if (attachmentRequest.getContent() != null) {
+				conjunction.add(cb.equal(aPath.get("content"), cb.literal(attachmentRequest.getContent())));
+
+			}
+			conjunction.add(cb.equal(aRoot.get("snooze").get("snoozeCase").get("internalId"), root.get("internalId")));
+			sq.where(conjunction.toArray(new Predicate[0]));
+			return cb.exists(sq);
+		};
+	}
+
+	private Specification<FilterableCase> caseExtraDataSpec(Map<String, Object> fieldFilter) {
+		String jsonQuery = new JSONObject(fieldFilter).toString();
+		return (root, query, cb) -> cb.isTrue(
+				cb.function(JsonOperatorContributor.JSON_CONTAINS, Boolean.class, root.get("extraData"), cb.literal(jsonQuery)));
+	}
+
+	private Specification<FilterableCase> caseCategorySpec(CaseSnoozeFilter queryFilter) {
+		switch (queryFilter) {
+			case ACTIVE:
+				return (root, query, cb) -> cb.or(
+						cb.lessThan(root.get("snoozeEnd"), cb.currentTimestamp()),
+						cb.isNull(root.get("snoozeEnd"))
+				);
+			case SNOOZED:
+				return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("snoozeEnd"), cb.currentTimestamp());
+			case ALARMED:
+				return (root, query, cb) -> cb.lessThan(root.get("snoozeEnd"), cb.currentTimestamp());
+			case UNCHECKED:
+				return (root, query, cb) -> cb.isNull(root.get("snoozeEnd"));
+			default:
+				throw new IllegalArgumentException();
+		}
+	}
+
+	private List<CaseSummary> wrapFetched(Specification<FilterableCase> mainSpec, Pageable pageInfo) {
+		try {
+			LOG.debug("Starting fetch using {}/{}", mainSpec, pageInfo);
+			Slice<FilterableCase> page = _repo.findAll(mainSpec, pageInfo);
+			LOG.debug("Finished fetch using {}/{}", mainSpec, pageInfo);
+			List<FilterableCase> cases = page.getContent();
+			Map<Long, List<AttachmentSummary>> attachments = fetchAllAttachments(cases);
+			return cases.stream()
+					.map(c -> new DelegatingSummary(c, attachments.get(c.getInternalId())))
+					.collect(Collectors.toList());
+		} catch (InvalidDataAccessApiUsageException e) {
+			if (e.getCause() instanceof IllegalArgumentException) {
+				throw (IllegalArgumentException) e.getCause();
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	private Map<Long, List<AttachmentSummary>> fetchAllAttachments(List<FilterableCase> cases) {
+		List<Long> caseIds = cases.stream().map(FilterableCase::getInternalId).collect(Collectors.toList());
+		List<CaseAttachmentAssociation> associations = _attachmentAssociationRepo.findAllBySnoozeSnoozeCaseInternalIdIn(caseIds);
+		Map<Long, List<AttachmentSummary>> attachments = new HashMap<>();
+		for (CaseAttachmentAssociation assoc : associations) {
+			Long caseId = assoc.getSnooze().getSnoozeCase().getInternalId();
+			List<AttachmentSummary> attachmentList = attachments.get(caseId);
+			if (attachmentList == null) {
+				attachmentList = new ArrayList<>();
+				attachments.put(caseId, attachmentList);
+			}
+			attachmentList.add(new AttachmentSummary(assoc));
+		}
+		return attachments;
+	}
+
+	private Specification<FilterableCase> commonSpec(
+			String caseManagementSystemTag,
+			String caseTypeTag,
+			Sort sortOrder,
+			Optional<String> pageReference, Optional<DateRange> caseCreationRange) {
+		CasePageInfo path = _translator.translatePath(caseManagementSystemTag, caseTypeTag, pageReference.orElse(null)); 
+		Specification<FilterableCase> fullSpec = pathSpec(path);
+		if (!path.isFirstPage()) {
+			fullSpec = fullSpec.and(pageSpec(path.getCase(), sortOrder));
+		}
+		if (caseCreationRange.isPresent()) {
+			DateRange dateRange = caseCreationRange.get();
+			Specification<FilterableCase> dateSpec = (root, query, cb) -> cb.and(
+				cb.greaterThanOrEqualTo(root.get("caseCreation"), dateRange.getStartDate()),
+				cb.lessThanOrEqualTo(root.get("caseCreation"), dateRange.getEndDate())
+			);
+			fullSpec = fullSpec.and(dateSpec);
+		}
+		return fullSpec;
+	}
+
+	private Specification<FilterableCase> pageSpec(FilterableCase troubleCase, Sort sortOrder) {
+		FilterableCase snuck = troubleCase;
+		Map<String, Function<FilterableCase, Comparable<?>>> lookup = new HashMap<>();
+		lookup.put("caseCreation", FilterableCase::getCaseCreation);
+		lookup.put("receiptNumber", FilterableCase::getReceiptNumber);
+		lookup.put("snoozeEnd", e -> { // slightly gross workaround
+			ZonedDateTime snoozeEnd = e.getSnoozeEnd();
+			if (null == snoozeEnd || snoozeEnd.isBefore(ZonedDateTime.now())) {
+				throw new IllegalArgumentException("Page reference case was not snoozed");
+			}
+			return snoozeEnd;
+		});
+
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		Specification<FilterableCase> keySet = (root, query, cb) -> {
+			List<Predicate> priorFields = new ArrayList<>();
+			List<Predicate> alternates = new ArrayList<>();
+			for (Order o : sortOrder) {
+				String property = o.getProperty();
+				Comparable val = lookup.get(property).apply(snuck);
+				if (val == null) {
+					throw new IllegalArgumentException("Property " + property + " cannot be found via page reference");
+				}
+				List<Predicate> conjunction = new ArrayList<>(priorFields);
+				Path<Comparable> field = root.get(property);
+				Expression<Comparable> placeholder = cb.literal(val);
+				conjunction.add(o.isAscending() ? cb.greaterThan(field, placeholder) : cb.lessThan(field, placeholder));
+				alternates.add(cb.and(conjunction.toArray(new Predicate[conjunction.size()])));
+				priorFields.add(cb.equal(field, placeholder));	
+			}
+			return cb.or(alternates.toArray(new Predicate[alternates.size()]));
+		};
+		return keySet;
+	}
+
+	private Specification<FilterableCase> pathSpec(CasePageInfo path) {
+		return (root1, query1, cb1) -> cb1.and(
+			cb1.equal(root1.get("caseManagementSystem"), path.getCaseManagementSystem()),
+			cb1.equal(root1.get("caseType"), path.getCaseType()),
+			// this should probably do the subquery directly rather than using the one in the view
+			cb1.isTrue(root1.get("hasOpenIssue"))
+		);
+	}
+
+	private static class DelegatingSummary implements CaseSummary {
+		private FilterableCase _root;
+		private List<AttachmentSummary> _attachments;
+
+		public DelegatingSummary(FilterableCase r, List<AttachmentSummary> attachments) {
+			_root = r;
+			_attachments = attachments;
+			if (attachments == null) {
+				_attachments = Collections.emptyList();
+			}
+		}
+		@Override
+		public String getReceiptNumber() {
+			return _root.getReceiptNumber();
+		}
+		@Override
+		public ZonedDateTime getCaseCreation() {
+			return _root.getCaseCreation();
+		}
+		@Override
+		public Map<String, Object> getExtraData() {
+			return _root.getExtraData();
+		}
+		@Override
+		public boolean isPreviouslySnoozed() {
+			return false;
+		}
+		@Override
+		public CaseSnoozeSummary getSnoozeInformation() {
+			return new CaseSnoozeSummary() {
+				@Override
+				public ZonedDateTime getSnoozeStart() {
+					return _root.getSnoozeStart();
+				}
+				
+				@Override
+				public String getSnoozeReason() {
+					return _root.getSnoozeReason();
+				}
+				
+				@Override
+				public ZonedDateTime getSnoozeEnd() {
+					return _root.getSnoozeEnd();
+				}
+			};
+		}
+		@Override
+		public List<AttachmentSummary> getNotes() {
+			return _attachments;
+		}
+	}
+	
+	
+}

--- a/src/main/java/gov/usds/case_issues/services/FilterFactory.java
+++ b/src/main/java/gov/usds/case_issues/services/FilterFactory.java
@@ -60,6 +60,10 @@ public class FilterFactory {
 	}
 
 	public static CaseFilter hasAttachment(AttachmentRequest attachmentRequest) {
+		return hasAttachment(attachmentRequest, true);
+	}
+
+	public static CaseFilter hasAttachment(AttachmentRequest attachmentRequest, boolean attachmentDesired) {
 		return (root, query, cb) -> {
 			Subquery<CaseAttachmentAssociation> sq = query.subquery(CaseAttachmentAssociation.class);
 			List<Predicate> conjunction = new ArrayList<>();
@@ -79,7 +83,8 @@ public class FilterFactory {
 			}
 			conjunction.add(cb.equal(aRoot.get("snooze").get("snoozeCase").get(MetaModel.ID), root.get(MetaModel.ID)));
 			sq.where(conjunction.toArray(new Predicate[0]));
-			return cb.exists(sq);
+			Predicate attachmentExists = cb.exists(sq);
+			return attachmentDesired ? attachmentExists : cb.not(attachmentExists) ;
 		};
 	}
 }

--- a/src/main/java/gov/usds/case_issues/services/FilterFactory.java
+++ b/src/main/java/gov/usds/case_issues/services/FilterFactory.java
@@ -10,6 +10,8 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import gov.usds.case_issues.db.JsonOperatorContributor;
@@ -21,6 +23,8 @@ import gov.usds.case_issues.services.model.CaseFilter;
 
 @Service
 public class FilterFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FilterFactory.class);
 
 	private static final class MetaModel {
 
@@ -63,10 +67,13 @@ public class FilterFactory {
 			sq.select(aRoot);
 			Path<CaseAttachment> aPath = aRoot.get("attachment");
 			conjunction.add(cb.equal(aPath.get("attachmentType"), cb.literal(attachmentRequest.getNoteType())));
+			LOG.debug("Filtering on attachment type {}", attachmentRequest.getNoteType());
 			if (attachmentRequest.getSubtype() != null) {
+				LOG.debug("Filtering on attachment subtype {}", attachmentRequest.getSubtype());
 				conjunction.add(cb.equal(aPath.get("attachmentSubtype").get(MetaModel.EXTERNAL_ID), cb.literal(attachmentRequest.getSubtype())));
 			}
 			if (attachmentRequest.getContent() != null) {
+				LOG.debug("Filtering on content {}", attachmentRequest.getContent());
 				conjunction.add(cb.equal(aPath.get("content"), cb.literal(attachmentRequest.getContent())));
 
 			}

--- a/src/main/java/gov/usds/case_issues/services/FilterFactory.java
+++ b/src/main/java/gov/usds/case_issues/services/FilterFactory.java
@@ -1,0 +1,78 @@
+package gov.usds.case_issues.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import gov.usds.case_issues.db.JsonOperatorContributor;
+import gov.usds.case_issues.db.model.CaseAttachment;
+import gov.usds.case_issues.db.model.CaseAttachmentAssociation;
+import gov.usds.case_issues.model.AttachmentRequest;
+import gov.usds.case_issues.model.DateRange;
+import gov.usds.case_issues.services.model.CaseFilter;
+
+@Service
+public class FilterFactory {
+
+	private static final class MetaModel {
+
+		private static final String CASE_CREATION = "caseCreation";
+		private static final String CASE_DETAIL_FIELDS = "extraData";
+		private static final String SNOOZE_REASON = "snoozeReason";
+
+		private static final String ID = "internalId";
+		private static final String EXTERNAL_ID = "externalId";
+	}
+
+	public static CaseFilter dateRange(DateRange dateRange) {
+		CaseFilter dateSpec = (root, query, cb) -> cb.and(
+			cb.greaterThanOrEqualTo(root.get(MetaModel.CASE_CREATION), dateRange.getStartDate()),
+			cb.lessThanOrEqualTo(root.get(MetaModel.CASE_CREATION), dateRange.getEndDate())
+		);
+		return dateSpec;
+	}
+
+	public static CaseFilter caseExtraData(Map<String, Object> fieldFilter) {
+		String jsonQuery = new JSONObject(fieldFilter).toString();
+		return (root, query, cb) -> cb.isTrue(
+			cb.function(JsonOperatorContributor.JSON_CONTAINS,
+				Boolean.class,
+				root.get(MetaModel.CASE_DETAIL_FIELDS),
+				cb.literal(jsonQuery)
+			)
+		);
+	}
+
+	public static CaseFilter snoozeReason(String reason) {
+		return (root, query, cb) -> cb.equal(root.get(MetaModel.SNOOZE_REASON), reason);
+	}
+
+	public static CaseFilter hasAttachment(AttachmentRequest attachmentRequest) {
+		return (root, query, cb) -> {
+			Subquery<CaseAttachmentAssociation> sq = query.subquery(CaseAttachmentAssociation.class);
+			List<Predicate> conjunction = new ArrayList<>();
+			Root<CaseAttachmentAssociation> aRoot = sq.from(CaseAttachmentAssociation.class);
+			sq.select(aRoot);
+			Path<CaseAttachment> aPath = aRoot.get("attachment");
+			conjunction.add(cb.equal(aPath.get("attachmentType"), cb.literal(attachmentRequest.getNoteType())));
+			if (attachmentRequest.getSubtype() != null) {
+				conjunction.add(cb.equal(aPath.get("attachmentSubtype").get(MetaModel.EXTERNAL_ID), cb.literal(attachmentRequest.getSubtype())));
+			}
+			if (attachmentRequest.getContent() != null) {
+				conjunction.add(cb.equal(aPath.get("content"), cb.literal(attachmentRequest.getContent())));
+
+			}
+			conjunction.add(cb.equal(aRoot.get("snooze").get("snoozeCase").get(MetaModel.ID), root.get(MetaModel.ID)));
+			sq.where(conjunction.toArray(new Predicate[0]));
+			return cb.exists(sq);
+		};
+	}
+}

--- a/src/main/java/gov/usds/case_issues/services/model/CaseFilter.java
+++ b/src/main/java/gov/usds/case_issues/services/model/CaseFilter.java
@@ -1,0 +1,12 @@
+package gov.usds.case_issues.services.model;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
+
+/**
+ * A possibly ill-advised marker interface for our services to pass to and from one another.
+ */
+public interface CaseFilter extends Specification<FilterableCase> {
+
+}

--- a/src/main/java/gov/usds/case_issues/services/model/CasePageInfo.java
+++ b/src/main/java/gov/usds/case_issues/services/model/CasePageInfo.java
@@ -4,17 +4,17 @@ import java.time.ZonedDateTime;
 
 import gov.usds.case_issues.db.model.CaseManagementSystem;
 import gov.usds.case_issues.db.model.CaseType;
-import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
 
 public class CasePageInfo extends CaseGroupInfo {
 
-	private TroubleCase _case;
+	private FilterableCase _case;
 
-	public CasePageInfo(CaseGroupInfo group, TroubleCase c) {
+	public CasePageInfo(CaseGroupInfo group, FilterableCase c) {
 		this(group.getCaseManagementSystem(), group.getCaseType(), c);
 	}
 
-	public CasePageInfo(CaseManagementSystem system, CaseType type, TroubleCase c) {
+	public CasePageInfo(CaseManagementSystem system, CaseType type, FilterableCase c) {
 		super(system, type);
 		_case = c;
 	}
@@ -23,7 +23,7 @@ public class CasePageInfo extends CaseGroupInfo {
 		return _case == null;
 	}
 
-	public TroubleCase getCase() {
+	public FilterableCase getCase() {
 		assertCase();
 		return _case;
 	}

--- a/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
@@ -1,0 +1,73 @@
+package gov.usds.case_issues.services.model;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
+import gov.usds.case_issues.db.model.reporting.FilterableCase;
+import gov.usds.case_issues.model.AttachmentSummary;
+import gov.usds.case_issues.model.CaseSummary;
+
+/**
+ * A delegating façade that implements the {@link CaseSummary} interface by wrapping a {@link FilterableCase}. 
+ */
+public class DelegatingFilterableCaseSummary implements CaseSummary {
+
+	private FilterableCase _root;
+	private List<AttachmentSummary> _attachments;
+
+	public DelegatingFilterableCaseSummary(FilterableCase r, List<AttachmentSummary> attachments) {
+		_root = r;
+		_attachments = attachments;
+		if (attachments == null) {
+			_attachments = Collections.emptyList();
+		}
+	}
+	@Override
+	public String getReceiptNumber() {
+		return _root.getReceiptNumber();
+	}
+	@Override
+	public ZonedDateTime getCaseCreation() {
+		return _root.getCaseCreation();
+	}
+	@Override
+	public Map<String, Object> getExtraData() {
+		return _root.getExtraData();
+	}
+	@Override
+	public boolean isPreviouslySnoozed() {
+		return false;
+	}
+	@Override
+	public CaseSnoozeSummary getSnoozeInformation() {
+		return new DelegatingSnoozeSummary();
+	}
+	@Override
+	public List<AttachmentSummary> getNotes() {
+		return _attachments;
+	}
+
+	/**
+	 * A delegating wrapper that implements {@link CaseSnooozeSummary} by wrapping the same root
+	 * {@link FilterableCase} as the parent object.
+	 */
+	private final class DelegatingSnoozeSummary implements CaseSnoozeSummary {
+		@Override
+		public ZonedDateTime getSnoozeStart() {
+			return _root.getSnoozeStart();
+		}
+
+		@Override
+		public String getSnoozeReason() {
+			return _root.getSnoozeReason();
+		}
+
+		@Override
+		public ZonedDateTime getSnoozeEnd() {
+			return _root.getSnoozeEnd();
+		}
+	}
+}

--- a/src/main/java/gov/usds/case_issues/validators/FilterParameter.java
+++ b/src/main/java/gov/usds/case_issues/validators/FilterParameter.java
@@ -1,0 +1,26 @@
+package gov.usds.case_issues.validators;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Pattern;
+
+/**
+ * Constraint to validate parameter names for HTTP endpoints with variable query-string parameters.
+ */
+@Constraint(validatedBy = { })
+@Pattern(regexp="\\w+(?:\\[\\w+\\])*")
+@Documented
+@Retention(RUNTIME)
+@Target({ TYPE_USE })
+public @interface FilterParameter {
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+    String message() default "Parameter names must be simple strings or dictionary entries";
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -522,4 +522,44 @@ databaseChangeLog:
         - addPrimaryKey:
             tableName: user_session_attributes
             columnNames: session_primary_id, attribute_name
+  - changeSet:
+      id: filterable-case-view
+      author: ben.warfield@usds.dhs.gov
+      comment: Create view that exposes the case and snooze information we want for the main query API.
+      changes:
+        - createView:
+            viewName: filterable_case_view
+            selectQuery: |
+              SELECT
+                c.internal_id,
+                c.created_at,
+                c.created_by,
+                c.updated_at,
+                c.updated_by,
+                c.case_management_system_internal_id,
+                c.case_type_internal_id,
+                c.receipt_number,
+                c.case_creation,
+                c.extra_data::jsonb as extra_data_converted,
+                s.internal_id as snooze_id,
+                s.snooze_reason,
+                s.snooze_start,
+                s.snooze_end,
+                s.created_at snooze_created_at,
+                s.created_by snooze_created_by,
+                s.updated_at as snooze_updated_at,
+                s.updated_by as snooze_updated_by,
+                exists (
+                  select case_issue.internal_id
+                  from ${database.defaultSchemaName}.case_issue
+                  where c.internal_id=case_issue.issue_case_internal_id
+                    and issue_closed is null
+                ) as has_open_issue
+              FROM
+                ${database.defaultSchemaName}.trouble_case c
+                LEFT JOIN (
+                  SELECT DISTINCT ON(snooze_case_internal_id) *
+                  from ${database.defaultSchemaName}.case_snooze
+                  order by snooze_case_internal_id, created_at desc
+                ) s on s.snooze_case_internal_id = c.internal_id
 

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
@@ -153,6 +153,16 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	}
 
 	@Test
+	public void snoozedCases_withoutComment_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(ANY_COMMENT, "false");
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED01, FixtureCase.SNOOZED03))
+		;
+	}
+
+	@Test
 	public void snoozedCases_withSpecificComment_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(COMMENT_CONTENT, FixtureAttachment.COMMENT2.name());

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
@@ -1,0 +1,221 @@
+package gov.usds.case_issues.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import gov.usds.case_issues.model.CaseSnoozeFilter;
+import gov.usds.case_issues.test_util.CaseListFixtureService;
+import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureAttachment;
+import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
+import gov.usds.case_issues.test_util.CaseListFixtureService.Keywords;
+
+@WithMockUser(authorities="READ_CASES")
+public class HitlistApiControllerFilteringTest extends ControllerTestBase {
+
+	private static final String PARITY_FILTER = "filter_dataField[parity]";
+	private static final String ANY_LINK = "filter_hasLinkType";
+	private static final String TROUBLE_LINK = "filter_hasLink[trouble]";
+	@Autowired
+	private CaseListFixtureService _fixtures;
+
+	@Before
+	public void reset() {
+		_fixtures.initFixtures();
+	}
+
+	@Test
+	public void snoozedCases_noFilter_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED01))
+		;
+	}
+
+	@Test
+	public void snoozedCases_withTicket_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(ANY_LINK, "trouble");
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED02, FixtureCase.SNOOZED04, FixtureCase.SNOOZED03))
+		;
+	}
+
+	@Test
+	public void alarmedCases_withTicket_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(ANY_LINK, "trouble");
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.DESNOOZED01))
+		;
+	}
+
+	@Test
+	public void alarmedCases_withSpecificGoodTicket_oneCase() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(TROUBLE_LINK, FixtureAttachment.LINK01.name());
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.DESNOOZED01))
+		;
+	}
+
+	@Test
+	public void alarmedCases_withSpecificBadTicket_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(TROUBLE_LINK, FixtureAttachment.LINK02.name());
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList())
+		;
+	}
+
+	@Test
+	public void snoozedCases_withColorTag_oneResult() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add("filter_hasTagType", "color");
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED02))
+		;
+	}
+
+	@Test
+	public void snoozedCases_withNonexistentTicket_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(TROUBLE_LINK, "NOPE");
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList());
+	}
+
+	@Test
+	public void snoozedCases_withLinkTypeNameSwitch_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(TROUBLE_LINK, FixtureAttachment.LINKEXT1.name());
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList());
+	}
+
+	@Test
+	public void snoozedCases_withTagTicketNameSwitch_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(TROUBLE_LINK, FixtureAttachment.TAG_BLUE.name());
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList());
+	}
+
+	@Test
+	public void snoozedCases_withTagTicketTypeSwitch_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add("filter_hasLink[color]", FixtureAttachment.TAG_BLUE.name());
+		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList());
+	}
+
+	@Test
+	public void snoozedCases_withComment_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add("filter_hasAnyComment", "true");
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED04))
+		;
+	}
+
+	@Test
+	public void snoozedCases_withSpecificComment_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add("filter_hasComment", FixtureAttachment.COMMENT2.name());
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED04))
+		;
+	}
+
+	@Test
+	public void snoozedCases_dataParityEven_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(PARITY_FILTER, Keywords.EVEN);
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED03))
+		;
+	}
+
+	@Test
+	public void uncheckedCases_dataParityEven_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(PARITY_FILTER, Keywords.EVEN);
+		doGetCases(CaseSnoozeFilter.UNCHECKED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.ACTIVE03, FixtureCase.ACTIVE05))
+		;
+	}
+	@Test
+	public void snoozedCases_dataParityEvenLaterPage_correctList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add(PARITY_FILTER, Keywords.EVEN);
+		additional.add("pageReference", FixtureCase.SNOOZED05.name());
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(caseJson(FixtureCase.SNOOZED02, FixtureCase.SNOOZED03))
+		;
+	}
+
+	@Test
+	public void snoozedCases_dataUnknownField_emptyList() throws Exception {
+		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
+		additional.add("filter_dataField[fred]", Keywords.EVEN);
+		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+			.andExpect(status().isOk())
+			.andExpect(emptyJsonList())
+		;
+	}
+
+	private static ResultMatcher emptyJsonList() {
+		return content().json("[]", true);
+	}
+
+	private ResultMatcher caseJson(FixtureCase... cases) {
+		return jsonPath("$[*].receiptNumber").value(Stream.of(cases).map(c -> c.name()).collect(Collectors.toList()));
+	}
+
+	private ResultActions doGetCases(CaseSnoozeFilter main, int pageSize, MultiValueMap<String, String> additional) throws Exception {
+		return doGetCases(Collections.singleton(main), pageSize, additional);
+	}
+
+	private ResultActions doGetCases(Set<CaseSnoozeFilter> main, int pageSize, MultiValueMap<String, String> additional) throws Exception {
+		MultiValueMap<String, String> baseParams = new LinkedMultiValueMap<>();
+		baseParams.put("mainFilter", main.stream().map(CaseSnoozeFilter::name).collect(Collectors.toList()));
+		baseParams.add("size", Integer.toString(pageSize));
+		MockHttpServletRequestBuilder req = get(HitlistApiControllerTest.API_PATH, CaseListFixtureService.SYSTEM, CaseListFixtureService.CASE_TYPE)
+			.params(baseParams)
+			.params(additional)
+			;
+		return perform(req);
+	}
+
+}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
@@ -29,6 +29,7 @@ import gov.usds.case_issues.test_util.CaseListFixtureService.Keywords;
 @WithMockUser(authorities="READ_CASES")
 public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 
+	private static final int DEFAULT_PAGE_SIZE = 3;
 	private static final String PARITY_FILTER = "filter_dataField[parity]";
 	private static final String ANY_LINK = "filter_hasLinkType";
 	private static final String TROUBLE_LINK = "filter_hasLink[trouble]";
@@ -43,7 +44,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_noFilter_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED01))
 		;
@@ -53,7 +54,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withTicket_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(ANY_LINK, "trouble");
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED02, FixtureCase.SNOOZED04, FixtureCase.SNOOZED03))
 		;
@@ -63,7 +64,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void alarmedCases_withTicket_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(ANY_LINK, "trouble");
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.DESNOOZED01))
 		;
@@ -73,7 +74,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void alarmedCases_withSpecificGoodTicket_oneCase() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(TROUBLE_LINK, FixtureAttachment.LINK01.name());
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.DESNOOZED01))
 		;
@@ -83,7 +84,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void alarmedCases_withSpecificBadTicket_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(TROUBLE_LINK, FixtureAttachment.LINK02.name());
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList())
 		;
@@ -93,7 +94,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withColorTag_oneResult() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add("filter_hasTagType", "color");
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED02))
 		;
@@ -103,7 +104,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withNonexistentTicket_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(TROUBLE_LINK, "NOPE");
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList());
 	}
@@ -112,7 +113,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withLinkTypeNameSwitch_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(TROUBLE_LINK, FixtureAttachment.LINKEXT1.name());
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList());
 	}
@@ -121,7 +122,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withTagTicketNameSwitch_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(TROUBLE_LINK, FixtureAttachment.TAG_BLUE.name());
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList());
 	}
@@ -130,7 +131,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withTagTicketTypeSwitch_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add("filter_hasLink[color]", FixtureAttachment.TAG_BLUE.name());
-		doGetCases(CaseSnoozeFilter.ALARMED, 3, additional)
+		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList());
 	}
@@ -139,7 +140,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withComment_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add("filter_hasAnyComment", "true");
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED04))
 		;
@@ -149,7 +150,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_withSpecificComment_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add("filter_hasComment", FixtureAttachment.COMMENT2.name());
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED04))
 		;
@@ -159,7 +160,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_dataParityEven_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(PARITY_FILTER, Keywords.EVEN);
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED03))
 		;
@@ -169,7 +170,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void uncheckedCases_dataParityEven_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(PARITY_FILTER, Keywords.EVEN);
-		doGetCases(CaseSnoozeFilter.UNCHECKED, 3, additional)
+		doGetCases(CaseSnoozeFilter.UNCHECKED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.ACTIVE03, FixtureCase.ACTIVE05))
 		;
@@ -179,7 +180,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add(PARITY_FILTER, Keywords.EVEN);
 		additional.add("pageReference", FixtureCase.SNOOZED05.name());
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED02, FixtureCase.SNOOZED03))
 		;
@@ -189,7 +190,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	public void snoozedCases_dataUnknownField_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
 		additional.add("filter_dataField[fred]", Keywords.EVEN);
-		doGetCases(CaseSnoozeFilter.SNOOZED, 3, additional)
+		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList())
 		;

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
@@ -25,14 +25,20 @@ import gov.usds.case_issues.test_util.CaseListFixtureService;
 import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureAttachment;
 import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
 import gov.usds.case_issues.test_util.CaseListFixtureService.Keywords;
+import gov.usds.case_issues.controllers.HitlistApiController.FilterParams;
 
 @WithMockUser(authorities="READ_CASES")
 public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 
+	private static final String TAG_TYPE = FilterParams.STEM + FilterParams.TAG_BY_TYPE;
+	private static final String ANY_COMMENT = FilterParams.STEM + FilterParams.COMMENT_ANY;
+	private static final String COMMENT_CONTENT = FilterParams.STEM + FilterParams.COMMENT_CONTENT;
+	private static final String PARITY_FILTER = dataFieldFilter(Keywords.PARITY);
+	private static final String LINK_TYPE = FilterParams.STEM + FilterParams.LINK_BY_TYPE;
+	private static final String TROUBLE_LINK = linkContentFilter("trouble");
+
 	private static final int DEFAULT_PAGE_SIZE = 3;
-	private static final String PARITY_FILTER = "filter_dataField[parity]";
-	private static final String ANY_LINK = "filter_hasLinkType";
-	private static final String TROUBLE_LINK = "filter_hasLink[trouble]";
+
 	@Autowired
 	private CaseListFixtureService _fixtures;
 
@@ -53,7 +59,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_withTicket_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add(ANY_LINK, "trouble");
+		additional.add(LINK_TYPE, "trouble");
 		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED02, FixtureCase.SNOOZED04, FixtureCase.SNOOZED03))
@@ -63,7 +69,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void alarmedCases_withTicket_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add(ANY_LINK, "trouble");
+		additional.add(LINK_TYPE, "trouble");
 		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.DESNOOZED01))
@@ -93,7 +99,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_withColorTag_oneResult() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add("filter_hasTagType", "color");
+		additional.add(TAG_TYPE, "color");
 		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED02))
@@ -130,7 +136,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_withTagTicketTypeSwitch_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add("filter_hasLink[color]", FixtureAttachment.TAG_BLUE.name());
+		additional.add(linkContentFilter("color"), FixtureAttachment.TAG_BLUE.name());
 		doGetCases(CaseSnoozeFilter.ALARMED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList());
@@ -139,7 +145,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_withComment_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add("filter_hasAnyComment", "true");
+		additional.add(ANY_COMMENT, "true");
 		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED04))
@@ -149,7 +155,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_withSpecificComment_correctList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add("filter_hasComment", FixtureAttachment.COMMENT2.name());
+		additional.add(COMMENT_CONTENT, FixtureAttachment.COMMENT2.name());
 		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(caseJson(FixtureCase.SNOOZED05, FixtureCase.SNOOZED04))
@@ -189,13 +195,19 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 	@Test
 	public void snoozedCases_dataUnknownField_emptyList() throws Exception {
 		MultiValueMap<String, String> additional = new LinkedMultiValueMap<>();
-		additional.add("filter_dataField[fred]", Keywords.EVEN);
+		additional.add(dataFieldFilter("fred"), Keywords.EVEN);
 		doGetCases(CaseSnoozeFilter.SNOOZED, DEFAULT_PAGE_SIZE, additional)
 			.andExpect(status().isOk())
 			.andExpect(emptyJsonList())
 		;
 	}
 
+	private static String dataFieldFilter(String field) {
+		return String.format(FilterParams.STEM + FilterParams.DATA_FIELD + "[%s]", field);
+	}
+	private static String linkContentFilter(String subtype) {
+		return String.format(FilterParams.STEM + FilterParams.LINK_BY_CONTENT + "[%s]", subtype);
+	}
 	private static ResultMatcher emptyJsonList() {
 		return content().json("[]", true);
 	}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -232,8 +232,6 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 			.andExpect(status().isBadRequest());
 		perform(doGetCases().param(Filters.MAIN, "FAKE"))
 			.andExpect(status().isBadRequest());
-		perform(doGetCases().param(Filters.MAIN, "UNCHECKED"))
-			.andExpect(status().isBadRequest());
 	}
 
 	@Test

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -33,7 +33,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	private static final String VALUE_ISSUE_TYPE = "WONKY";
 	private static final String VALID_CASE_TYPE = "C1";
 	private static final String VALID_CASE_MGT_SYS = "F1";
-	private static final String API_PATH = "/api/cases/{caseManagementSystemTag}/{caseTypeTag}/";
+	protected static final String API_PATH = "/api/cases/{caseManagementSystemTag}/{caseTypeTag}/";
 	private static final String ISSUE_UPLOAD_PATH = API_PATH + "{issueTag}";
 	private static final String CASE_TYPE_NOPE = "Case Type 'NOPE' was not found";
 	private static final String CASE_MANAGEMENT_SYSTEM_NOPE = "Case Management System 'NOPE' was not found";
@@ -343,6 +343,23 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 			.andExpect(content().json("[]", true))
 		;
 	}
+
+	@Test
+	public void getCases_invalidAdditionalParamNames_badRequest() throws Exception {
+		perform(doGetCases().param(Filters.MAIN, "ALARMED").param("+nope", "1", "2", "3"))
+			.andExpect(status().isBadRequest())
+		;
+		perform(doGetCases().param(Filters.MAIN, "ALARMED").param("-flag", "true"))
+			.andExpect(status().isBadRequest())
+		;
+		perform(doGetCases().param(Filters.MAIN, "ALARMED").param("inject\nme", "plzkthx"))
+			.andExpect(status().isBadRequest())
+		;
+		perform(doGetCases().param(Filters.MAIN, "ALARMED").param("filter on awesomeness", "true"))
+			.andExpect(status().isBadRequest())
+		;
+	}
+
 	/**
 	 * Create some data on our default case type!
 	 *

--- a/src/test/java/gov/usds/case_issues/services/CaseFilteringServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseFilteringServiceTest.java
@@ -1,0 +1,15 @@
+package gov.usds.case_issues.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CaseFilteringServiceTest extends CaseListPagingFilteringTest {
+
+	@Autowired
+	private CaseFilteringService _service;
+
+	@Override
+	protected CasePagingService getService() {
+		return _service;
+	}
+	
+}

--- a/src/test/java/gov/usds/case_issues/services/CaseFilteringServiceTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseFilteringServiceTest.java
@@ -1,7 +1,25 @@
 package gov.usds.case_issues.services;
 
+import static gov.usds.case_issues.test_util.CaseListFixtureService.CASE_TYPE;
+import static gov.usds.case_issues.test_util.CaseListFixtureService.SYSTEM;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import gov.usds.case_issues.db.model.AttachmentType;
+import gov.usds.case_issues.model.AttachmentRequest;
+import gov.usds.case_issues.model.CaseSnoozeFilter;
+import gov.usds.case_issues.model.CaseSummary;
+import gov.usds.case_issues.test_util.CaseListFixtureService;
+import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
+import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureAttachment;
+
+@SuppressWarnings("checkstyle:MagicNumber")
 public class CaseFilteringServiceTest extends CaseListPagingFilteringTest {
 
 	@Autowired
@@ -11,5 +29,34 @@ public class CaseFilteringServiceTest extends CaseListPagingFilteringTest {
 	protected CasePagingService getService() {
 		return _service;
 	}
-	
+
+	@Test
+	public void getCases_uncheckedCasesFirstPage_correctResult() {
+		List<CaseSummary> foundCases = _service.getCases(CaseSnoozeFilter.UNCHECKED, SYSTEM, CASE_TYPE, null, Optional.empty(), 3, Optional.empty(),
+				Optional.empty(), Collections.emptyMap(), Optional.empty());
+		assertCaseOrder("active only!", Arrays.asList(FixtureCase.ACTIVE01, FixtureCase.ACTIVE04, FixtureCase.ACTIVE02), foundCases);
+	}
+
+	@Test
+	public void getCases_uncheckedCasesParityEven_correctResult() {
+		List<CaseSummary> foundCases = _service.getCases(CaseSnoozeFilter.UNCHECKED, SYSTEM, CASE_TYPE, null, Optional.empty(), 3, Optional.empty(),
+				Optional.empty(), Collections.singletonMap(CaseListFixtureService.Keywords.PARITY, CaseListFixtureService.Keywords.EVEN),
+				Optional.empty());
+		assertCaseOrder("active and even", Arrays.asList(FixtureCase.ACTIVE03, FixtureCase.ACTIVE05), foundCases);
+	}
+
+	@Test
+	public void getCases_snoozedCasesCorrelationIdAttached_correctResult() {
+		List<CaseSummary> foundCases = _service.getCases(CaseSnoozeFilter.SNOOZED, SYSTEM, CASE_TYPE, null, Optional.empty(), 3, Optional.empty(),
+			Optional.empty(), Collections.emptyMap(), Optional.of(FixtureAttachment.CORRELATION01.asRequest()));
+		assertCaseOrder("Snoozed with correlation ID", Arrays.asList(FixtureCase.SNOOZED02, FixtureCase.SNOOZED01), foundCases);
+	}
+
+	@Test
+	public void getCases_snoozedCasesAnyTroubleLink_correctResult() {
+		List<CaseSummary> foundCases = _service.getCases(CaseSnoozeFilter.SNOOZED, SYSTEM, CASE_TYPE, null, Optional.empty(), 5, Optional.empty(),
+				Optional.empty(), Collections.emptyMap(), Optional.of(new AttachmentRequest(AttachmentType.LINK, null, "trouble")));
+		assertCaseOrder("Snoozed with a trouble link", Arrays.asList(FixtureCase.SNOOZED02, FixtureCase.SNOOZED03, FixtureCase.SNOOZED04), foundCases);
+	}
+
 }

--- a/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/services/CaseListPagingFilteringTest.java
@@ -391,7 +391,7 @@ public abstract class CaseListPagingFilteringTest extends CaseIssueApiTestBase {
 		);
 	}
 
-	private static void assertCaseOrder(String message, List<FixtureCase> expected, List<? extends CaseSummary> foundCases) {
+	protected static void assertCaseOrder(String message, List<FixtureCase> expected, List<? extends CaseSummary> foundCases) {
 		List<String> foundReceipts = foundCases.stream().map(CaseSummary::getReceiptNumber).collect(Collectors.toList());
 		List<String> expectedReceipts = expected.stream().map(FixtureCase::name).collect(Collectors.toList());
 		assertEquals(message, expectedReceipts, foundReceipts);

--- a/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
+++ b/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
@@ -24,7 +24,6 @@ import gov.usds.case_issues.db.repositories.CaseSnoozeRepository;
 import gov.usds.case_issues.db.repositories.TroubleCaseRepository;
 import gov.usds.case_issues.model.AttachmentRequest;
 import gov.usds.case_issues.services.CaseAttachmentService;
-import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
 
 /**
  * This is an extraction from the paging/filtering tests, because having 36 test cases and all the

--- a/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
+++ b/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
@@ -65,7 +65,7 @@ public class CaseListFixtureService {
 
 	public static class Keywords {
 		public static final String PARITY = "parity";
-		private static final String EVEN = "even";
+		public static final String EVEN = "even";
 		public static final String ODD = "odd";
 	}
 

--- a/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
+++ b/src/test/java/gov/usds/case_issues/test_util/CaseListFixtureService.java
@@ -24,6 +24,7 @@ import gov.usds.case_issues.db.repositories.CaseSnoozeRepository;
 import gov.usds.case_issues.db.repositories.TroubleCaseRepository;
 import gov.usds.case_issues.model.AttachmentRequest;
 import gov.usds.case_issues.services.CaseAttachmentService;
+import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
 
 /**
  * This is an extraction from the paging/filtering tests, because having 36 test cases and all the
@@ -69,6 +70,19 @@ public class CaseListFixtureService {
 		public static final String ODD = "odd";
 	}
 
+	/**
+	 * An enumeration of all the cases we will create, in the order they will be created in the system.
+	 * For reference, here are the cases in their groups, in the order they come out in their respective
+	 * default sorts:
+	 * <ul>
+	 *   <li> FixtureCase.SNOOZED05, FixtureCase.SNOOZED02, FixtureCase.SNOOZED01, FixtureCase.SNOOZED04, FixtureCase.SNOOZED03</li>
+	 *   <li> FixtureCase.ACTIVE01, FixtureCase.DESNOOZED02, FixtureCase.DESNOOZED01,
+	 *        FixtureCase.ACTIVE04, FixtureCase.ACTIVE02, FixtureCase.ACTIVE03,
+	 *        FixtureCase.DESNOOZED03, FixtureCase.ACTIVE05, FixtureCase.DESNOOZED04
+	 *   </li>
+	 *   <li>FixtureCase.CLOSED01, FixtureCase.CLOSED02</li>
+	 * </ul>
+	 */
 	@SuppressWarnings("checkstyle:MagicNumber")
 	public enum FixtureCase {
 		/** An active case */


### PR DESCRIPTION
Recreated the existing list-fetch API using a view and a lot of Spring Data JPA chicanery.

* extracted a base class for TroubleCase to capture the things we wanted to filter on
* created a new view using postgresql `DISTINCT ON` to allow fetching a case along with its latest Snooze information, and created a mapped entity corresponding to that view
* created a new service that reimplements the old service, but also implements a more-flexible interface that allows for arbitrary filters to be passed to the core list-fetch method.
* added arguments to the main `getCases` HTTP endpoint to allow passing some of those arbitrary filters (link or tag subtype, specific link or tag, specific comment, existence of a comment)
* updated Swagger documentation, mostly by main force, to reflect new parameters.

Questions/follow-ups:
 - [ ] what is our plan for the `summary` endpoint?
 - [ ] what search/search-like filters should we add? (e.g. partial receipt match, receipt/comment consolidated match, receipt-list search...)
 - [ ] are the queries generated for new filters reasonably optimal/optimizable by the pg query planner?