### PR TITLE
Force cookies to be issued with SameSite=None.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// this next line is only here so we can tweak the cookie serializer to set SameSite:
+	// otherwise, a runtimeOnly dependency on spring-session-jdbc would be sufficient.
+	implementation 'org.springframework.session:spring-session-core'
+	runtimeOnly 'org.springframework.session:spring-session-jdbc'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	implementation 'org.springframework.data:spring-data-rest-hal-browser'
 	implementation 'org.springframework.retry:spring-retry'
@@ -48,7 +53,6 @@ dependencies {
 	implementation "org.liquibase:liquibase-core"
 
 	runtimeOnly 'org.postgresql:postgresql'
-	runtimeOnly 'org.springframework.session:spring-session-jdbc'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -96,6 +96,7 @@ org.springframework.security:spring-security-oauth2-client:5.1.6.RELEASE
 org.springframework.security:spring-security-oauth2-core:5.1.6.RELEASE
 org.springframework.security:spring-security-oauth2-jose:5.1.6.RELEASE
 org.springframework.security:spring-security-web:5.1.6.RELEASE
+org.springframework.session:spring-session-core:2.1.8.RELEASE
 org.springframework:spring-aop:5.1.9.RELEASE
 org.springframework:spring-aspects:5.1.9.RELEASE
 org.springframework:spring-beans:5.1.9.RELEASE

--- a/src/main/java/gov/usds/case_issues/config/WebConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/WebConfig.java
@@ -18,6 +18,8 @@ import org.springframework.http.converter.AbstractHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
@@ -78,6 +80,19 @@ public class WebConfig implements WebMvcConfigurer {
 		FilterRegistrationBean<JsonRedirectPreventingFilter> registration = new FilterRegistrationBean<>(new JsonRedirectPreventingFilter());
 		registration.setOrder(BEFORE_SECURITY);
 		return registration;
+	}
+
+	/**
+	 * Force cookies to set SameSite=None, since otherwise CORS requests will not work in compliant browsers.
+	 * At some future point (no earlier than when we upgrade to Spring Boot 2.2, and probably later) it will
+	 * be possible to replace this with one line in application.yml, at which point this should definitely be
+	 * deleted (and the compile-time dependency on spring-session-core can be removed).
+	 */
+	@Bean
+	public CookieSerializer getCookieSerializer() {
+		DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+		serializer.setSameSite("None");
+		return serializer;
 	}
 
 	/**

--- a/src/test/java/gov/usds/case_issues/controllers/SessionCookieTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/SessionCookieTest.java
@@ -1,0 +1,52 @@
+package gov.usds.case_issues.controllers;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+import org.junit.Test;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Tests to validate that our cookie configuration is working the way we think it is.
+ */
+public class SessionCookieTest extends ControllerTestBase {
+
+	private static final String SESSION_COOKIE = "SESSION";
+
+	@Test
+	public void vanillaRequest_expectedFlags() throws Exception {
+		perform(vanillaGet())
+			.andExpect(cookie().exists(SESSION_COOKIE))
+			.andExpect(cookie().secure(SESSION_COOKIE, false))
+			.andExpect(cookie().httpOnly(SESSION_COOKIE, true))
+			.andExpect(header().string("Set-Cookie", containsString("SameSite=None")))
+		;
+	}
+
+	@Test
+	public void forwardingHeadersUsed_secureSetCorrectly() throws Exception {
+		perform(vanillaGet().header("X-Forwarded-Proto", "https"))
+			.andExpect(cookie().exists(SESSION_COOKIE))
+			.andExpect(cookie().secure(SESSION_COOKIE, true))
+		;
+		perform(vanillaGet().header("Forwarded", "host=example.com;proto=https"))
+			.andExpect(cookie().exists(SESSION_COOKIE))
+			.andExpect(cookie().secure(SESSION_COOKIE, true))
+		;
+		perform(vanillaGet().header("X-Forwarded-Proto", "http"))
+			.andExpect(cookie().exists(SESSION_COOKIE))
+			.andExpect(cookie().secure(SESSION_COOKIE, false))
+		;
+		perform(vanillaGet().header("Forwarded", "host=example.com;proto=http"))
+			.andExpect(cookie().exists(SESSION_COOKIE))
+			.andExpect(cookie().secure(SESSION_COOKIE, false))
+		;
+	}
+
+	/** Perform a GET request to a URL that will set a session cookie without our needing to log in */
+	private MockHttpServletRequestBuilder vanillaGet() {
+		return get("/csrf");
+	}
+}


### PR DESCRIPTION
Added a lightly customized cookie serializer to force SameSite=None to always be set on our cookies, so that Chrome knows that we want this application to be usable for CORS requests.