### PR TITLE
Expose back-dated issue creation facility to HTTP API

### DIFF
--- a/src/main/java/gov/usds/case_issues/authorization/RequireUploadAndStructurePermission.java
+++ b/src/main/java/gov/usds/case_issues/authorization/RequireUploadAndStructurePermission.java
@@ -1,0 +1,24 @@
+package gov.usds.case_issues.authorization;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Very restrictive: require both the upload permission and the data-modification permission.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({METHOD, TYPE})
+@PreAuthorize(
+	  "hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_ISSUES.name())"
+	+ " and "
+	+ "hasAuthority(T(gov.usds.case_issues.authorization.CaseIssuePermission).UPDATE_STRUCTURE.name())"
+)
+public @interface RequireUploadAndStructurePermission {
+
+}

--- a/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
+++ b/src/main/java/gov/usds/case_issues/controllers/HitlistApiController.java
@@ -135,13 +135,28 @@ public class HitlistApiController {
 	public ResponseEntity<?> updateIssueListCsv(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
 			@RequestBody InputStream csvStream, @RequestParam(required=false) String uploadSchema) throws IOException {
 		CaseGroupInfo translated = _listService.translatePath(caseManagementSystemTag, caseTypeTag);
+		return processCsvUpload(translated, issueTag, csvStream, ZonedDateTime.now(), uploadSchema);
+	}
+
+	@RequireUploadAndStructurePermission
+	@PutMapping(value="/{issueTag}",consumes={"text/csv"}, params="effectiveDate")
+	public ResponseEntity<?> updateIssueListCsvWithBackdate(@PathVariable String caseManagementSystemTag, @PathVariable String caseTypeTag, @PathVariable String issueTag,
+			@RequestBody InputStream csvStream,
+			@RequestParam(required=true) @DateTimeFormat(iso=ISO.DATE_TIME) ZonedDateTime effectiveDate,
+			@RequestParam(required=false) String uploadSchema) throws IOException {
+		CaseGroupInfo translated = _listService.translatePath(caseManagementSystemTag, caseTypeTag);
+		return processCsvUpload(translated, issueTag, csvStream, effectiveDate, uploadSchema);
+	}
+
+	private ResponseEntity<?> processCsvUpload(CaseGroupInfo translated, String issueTag, InputStream csvStream,
+			ZonedDateTime effectiveDate, String uploadSchema) throws IOException {
 		CsvSchema schema = CsvSchema.emptySchema().withHeader();
 		MappingIterator<Map<String, Object>> valueIterator = new CsvMapper()
 			.readerFor(Map.class)
 			.with(schema)
 			.readValues(csvStream);
 		List<CaseRequest> newIssueCases = processCaseUploads(valueIterator, uploadSchema);
-		_uploadService.putIssueList(translated, issueTag, newIssueCases, ZonedDateTime.now());
+		_uploadService.putIssueList(translated, issueTag, newIssueCases, effectiveDate);
 		return ResponseEntity.accepted().build();
 	}
 

--- a/src/main/java/gov/usds/case_issues/controllers/errors/ApiControllerAdvice.java
+++ b/src/main/java/gov/usds/case_issues/controllers/errors/ApiControllerAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import gov.usds.case_issues.model.ApiModelNotFoundException;
+import gov.usds.case_issues.model.BusinessConstraintViolationException;
 
 @RestControllerAdvice("gov.usds.case_issues.controllers") // maybe make this type safe?
 public class ApiControllerAdvice {
@@ -46,4 +47,12 @@ public class ApiControllerAdvice {
 		LOG.warn("Got a data integrity violation!");
 		return new SpringRestError(e, HttpStatus.CONFLICT, req);
 	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public SpringRestError handleBusinessRuleViolation(BusinessConstraintViolationException e, HttpServletRequest req) {
+		LOG.warn("Got a business rule violation!", e);
+		return new SpringRestError(e, HttpStatus.CONFLICT, req);
+	}
+
 }

--- a/src/main/java/gov/usds/case_issues/model/BusinessConstraintViolationException.java
+++ b/src/main/java/gov/usds/case_issues/model/BusinessConstraintViolationException.java
@@ -1,0 +1,15 @@
+package gov.usds.case_issues.model;
+
+/**
+ * Exception to convey to the API consumer that a constraint other than a database constraint
+ * (i.e. a business rule implemented in Java) was violated. Should produce a 409 Conflict status,
+ * rather than a 400 Bad Request. 
+ */
+public class BusinessConstraintViolationException extends IllegalArgumentException {
+
+	private static final long serialVersionUID = 1L;
+
+	public BusinessConstraintViolationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/gov/usds/case_issues/services/CaseListService.java
+++ b/src/main/java/gov/usds/case_issues/services/CaseListService.java
@@ -332,10 +332,10 @@ public class CaseListService implements CasePagingService, PageTranslationServic
 		Map<String, Object> caseCounts = _bulkRepo.getSnoozeSummary(translated.getCaseManagementSystemId(), translated.getCaseTypeId())
 				.stream()
 				.collect(Collectors.toMap(a->((String) a[0]).trim(), a->(Number) a[1]));
-		CaseIssueUpload lastSuccess = _uploadStatusService.getLastUpload(
+		Optional<CaseIssueUpload> lastSuccess = _uploadStatusService.getLastUpload(
 			translated.getCaseManagementSystem(), translated.getCaseType(), UploadStatus.SUCCESSFUL);
-		if (lastSuccess != null) {
-			caseCounts.put("lastUpdated", lastSuccess.getEffectiveDate());
+		if (lastSuccess.isPresent()) {
+			caseCounts.put("lastUpdated", lastSuccess.get().getEffectiveDate());
 		}
 		return caseCounts;
 	}

--- a/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
+++ b/src/main/java/gov/usds/case_issues/services/UploadStatusService.java
@@ -3,6 +3,7 @@ package gov.usds.case_issues.services;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +41,8 @@ public class UploadStatusService {
 	public CaseIssueUpload commenceUpload(CaseManagementSystem sys, CaseType caseType, String issueType,
 	        ZonedDateTime effectiveDate, int uploadedRecords) {
 		LOG.debug("Checking previous upload record for {}/{}/{}", sys.getExternalId(), caseType.getExternalId(), issueType);
-		CaseIssueUpload previous = getLastUpload(sys, caseType, issueType);
-		if (previous != null && previous.getEffectiveDate().isAfter(effectiveDate)) {
+		Optional<CaseIssueUpload> previous = getLastUpload(sys, caseType, issueType);
+		if (previous.isPresent() && previous.get().getEffectiveDate().isAfter(effectiveDate)) {
 			throw new BusinessConstraintViolationException("Cannot back-date issue upload beyond the latest existing upload.");
 		}
 
@@ -72,13 +73,13 @@ public class UploadStatusService {
 		history.sort((a,b)->a.getEffectiveDate().compareTo(b.getEffectiveDate()));
 		return history;
 	}
-	public CaseIssueUpload getLastUpload(CaseManagementSystem sys, CaseType type, String issueTypeTag) {
+	public Optional<CaseIssueUpload> getLastUpload(CaseManagementSystem sys, CaseType type, String issueTypeTag) {
 		return _uploadRepository.findFirstByCaseManagementSystemAndCaseTypeAndIssueTypeAndUploadStatusOrderByEffectiveDateDesc(
-				sys, type, issueTypeTag, UploadStatus.SUCCESSFUL).orElse(null);
+				sys, type, issueTypeTag, UploadStatus.SUCCESSFUL);
 	}
-	public CaseIssueUpload getLastUpload(CaseManagementSystem sys, CaseType type, UploadStatus successful) {
+	public Optional<CaseIssueUpload> getLastUpload(CaseManagementSystem sys, CaseType type, UploadStatus successful) {
 		return _uploadRepository.findFirstByCaseManagementSystemAndCaseTypeAndUploadStatusOrderByEffectiveDateDesc(
-				sys, type, UploadStatus.SUCCESSFUL).orElse(null);
+				sys, type, successful);
 	}
 
 	/** Simple fetch-by-ID, for something where people rarely want to know the ID: initially just for test/verification */ 

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -193,18 +193,18 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_backDatedWithoutStructureAuthority_forbidden() throws Exception {
 		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
-				.param("effectiveDate", "2019-12-31T20:00:00Z")
-				.content(NO_OP);
-			perform(issuePut).andExpect(status().isForbidden());
+			.param("effectiveDate", "2019-12-31T20:00:00Z")
+			.content(NO_OP);
+		perform(issuePut).andExpect(status().isForbidden());
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_STRUCTURE")
 	public void putCsv_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
 		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
-				.param("effectiveDate", "2019-12-31T20:00:00Z")
-				.content(NO_OP);
-			perform(issuePut).andExpect(status().isForbidden());
+			.param("effectiveDate", "2019-12-31T20:00:00Z")
+			.content(NO_OP);
+		perform(issuePut).andExpect(status().isForbidden());
 	}
 
 	@Test
@@ -261,16 +261,16 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	public void putJson_backDatedWithoutStructureAuthority_forbidden() throws Exception {
 		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, "2019-12-31T20:00:00Z")
 				.content("[]");
-			perform(jsonPut).andExpect(status().isForbidden());
+		perform(jsonPut).andExpect(status().isForbidden());
 	}
 
 	@Test
 	@WithMockUser(authorities = "UPDATE_STRUCTURE")
 	public void putJson_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
 		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE)
-				.param("effectiveDate", "2019-12-31T20:00:00Z")
-				.content("[]");
-			perform(jsonPut).andExpect(status().isForbidden());
+			.param("effectiveDate", "2019-12-31T20:00:00Z")
+			.content("[]");
+		perform(jsonPut).andExpect(status().isForbidden());
 	}
 
 	@Test

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -1,7 +1,6 @@
 package gov.usds.case_issues.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -215,7 +214,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT, "2017-05-15T20:00:00Z")
 			.content(CSV_HEADER_SHORT + receiptNumber + ",2001-08-29T00:00:00-04:00,Pay Per View\n");
 		perform(issuePut).andExpect(status().isAccepted());
-		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
+		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
 		assertEquals(2017, lastUpload.getEffectiveDate().getYear());
 		assertEquals(Month.MAY, lastUpload.getEffectiveDate().getMonth());
 		assertEquals(15, lastUpload.getEffectiveDate().getDayOfMonth());
@@ -285,7 +284,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, "2019-12-31T20:00:00Z")
 				.content("[" + requestCase.toString() + "]");
 		perform(jsonPut).andExpect(status().isAccepted());
-		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
+		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
 		assertEquals(2019, lastUpload.getEffectiveDate().getYear());
 		assertEquals(Month.DECEMBER, lastUpload.getEffectiveDate().getMonth());
 		assertEquals(31, lastUpload.getEffectiveDate().getDayOfMonth());
@@ -495,8 +494,9 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	}
 
 	private void checkUploadRecord(int recordCount, int newIssues, int closedIssues) {
-		CaseIssueUpload uploadInfo = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
-		assertNotNull(uploadInfo);
+		Optional<CaseIssueUpload> maybeInfo = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
+		assertTrue(maybeInfo.isPresent());
+		CaseIssueUpload uploadInfo = maybeInfo.get();
 		assertEquals(UploadStatus.SUCCESSFUL, uploadInfo.getUploadStatus());
 		assertEquals(newIssues, uploadInfo.getNewIssueCount().intValue());
 		assertEquals(closedIssues, uploadInfo.getClosedIssueCount().intValue());

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -36,7 +36,9 @@ import gov.usds.case_issues.services.UploadStatusService;
 @SuppressWarnings("checkstyle:MagicNumber")
 public class HitlistApiControllerTest extends ControllerTestBase {
 
+	private static final String CSV_CONTENT = "text/csv";
 	private static final String NO_OP = "non-empty request body";
+
 	private static final String DATE_STAMP_2018 = "2018-01-01T12:00:00Z";
 	private static final String DATE_STAMP_2019 = "2019-01-01T12:00:00Z";
 	private static final String VALID_ISSUE_TYPE = "WONKY";
@@ -156,7 +158,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
+		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
 			.content("header1,header2\n");
 		perform(jsonPut).andExpect(status().isAccepted());
 		checkUploadRecord(0, 0, 0);
@@ -165,7 +167,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_singleCase_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
+		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
@@ -177,7 +179,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_invalidCreationDate_badRequest() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues("text/csv")
+		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
 				"FKE5250608,NOT A DATE,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
@@ -190,7 +192,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_ISSUES")
 	public void putCsv_backDatedWithoutStructureAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder issuePut = putIssues("text/csv")
+		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
 				.param("effectiveDate", "2019-12-31T20:00:00Z")
 				.content(NO_OP);
 			perform(issuePut).andExpect(status().isForbidden());
@@ -199,7 +201,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	@Test
 	@WithMockUser(authorities = "UPDATE_STRUCTURE")
 	public void putCsv_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder issuePut = putIssues("text/csv")
+		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
 				.param("effectiveDate", "2019-12-31T20:00:00Z")
 				.content(NO_OP);
 			perform(issuePut).andExpect(status().isForbidden());
@@ -211,7 +213,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		String receiptNumber = "FKE27182818";
 		String csvString = "receiptNumber,creationDate,channelType\n"
 			+ receiptNumber + ",2001-08-29T00:00:00-04:00,Pay PerView\n";
-		MockHttpServletRequestBuilder issuePut = putIssues("text/csv")
+		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
 				.param("effectiveDate", "2017-05-15T20:00:00Z")
 				.content(csvString);
 		perform(issuePut).andExpect(status().isAccepted());
@@ -279,7 +281,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	public void getSummary_emptyCasesAdded_lastActivePresent() throws Exception {
 		initCaseData();
 		perform(put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType("text/csv")
+			.contentType(CSV_CONTENT)
 			.with(csrf())
 			.content(
 				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -237,7 +237,7 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 
 	@Test
 	@WithMockUser(authorities = {"READ_CASES", "UPDATE_ISSUES"})
-	public void getSummary_emptyCasesAdded_lastActviePresent() throws Exception {
+	public void getSummary_emptyCasesAdded_lastActivePresent() throws Exception {
 		initCaseData();
 		perform(put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
 			.contentType("text/csv")


### PR DESCRIPTION
Added a method for highly privileged users to back-date issues when they are uploaded.