### PR TITLE
Added internal case-created/updated information to JSON API objects.

### DIFF
--- a/src/main/java/gov/usds/case_issues/model/CaseDetails.java
+++ b/src/main/java/gov/usds/case_issues/model/CaseDetails.java
@@ -37,15 +37,18 @@ public class CaseDetails implements PersistedCase {
 	public CaseManagementSystem getCaseManagementSystem() {
 		return rootCase.getCaseManagementSystem();
 	}
+	@Override
 	public String getReceiptNumber() {
 		return rootCase.getReceiptNumber();
 	}
 	public CaseType getCaseType() {
 		return rootCase.getCaseType();
 	}
+	@Override
 	public ZonedDateTime getCaseCreation() {
 		return rootCase.getCaseCreation();
 	}
+	@Override
 	public Map<String, Object> getExtraData() {
 		return rootCase.getExtraData();
 	}
@@ -53,6 +56,7 @@ public class CaseDetails implements PersistedCase {
 	public ZonedDateTime getCaseInitialUploadDate() {
 		 return ZonedDateTime.ofInstant(rootCase.getCreatedAt().toInstant(), GMT);
 	}
+	@Override
 	public ZonedDateTime getCaseDataModifiedDate() {
 		return ZonedDateTime.ofInstant(rootCase.getUpdatedAt().toInstant(), GMT);
 	}

--- a/src/main/java/gov/usds/case_issues/model/CaseDetails.java
+++ b/src/main/java/gov/usds/case_issues/model/CaseDetails.java
@@ -16,7 +16,7 @@ import gov.usds.case_issues.db.model.projections.CaseIssueSummary;
  * API Model for the full details of a {@link TroubleCase}, including all issues (open and closed)
  * and all snoozes (active and past) and notes.
  */
-public class CaseDetails {
+public class CaseDetails implements PersistedCase {
 
 	private TroubleCase rootCase;
 	private Collection<? extends CaseIssueSummary> issues;
@@ -48,6 +48,13 @@ public class CaseDetails {
 	}
 	public Map<String, Object> getExtraData() {
 		return rootCase.getExtraData();
+	}
+	@Override
+	public ZonedDateTime getCaseInitialUploadDate() {
+		 return ZonedDateTime.ofInstant(rootCase.getCreatedAt().toInstant(), GMT);
+	}
+	public ZonedDateTime getCaseDataModifiedDate() {
+		return ZonedDateTime.ofInstant(rootCase.getUpdatedAt().toInstant(), GMT);
 	}
 
 	@JsonSerialize(contentAs=CaseIssueSummary.class)

--- a/src/main/java/gov/usds/case_issues/model/CaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/model/CaseSummary.java
@@ -13,8 +13,6 @@ import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
  */
 public interface CaseSummary extends PersistedCase {
 
-	boolean isPreviouslySnoozed();
-
 	CaseSnoozeSummary getSnoozeInformation();
 
 	List<AttachmentSummary> getNotes();

--- a/src/main/java/gov/usds/case_issues/model/CaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/model/CaseSummary.java
@@ -11,7 +11,7 @@ import gov.usds.case_issues.db.model.projections.CaseSnoozeSummary;
  * previously-snoozed case (a shortcut for checking for snooze information and then checking if the
  * snooze has expired).
  */
-public interface CaseSummary extends CaseRequest {
+public interface CaseSummary extends PersistedCase {
 
 	boolean isPreviouslySnoozed();
 

--- a/src/main/java/gov/usds/case_issues/model/PersistedCase.java
+++ b/src/main/java/gov/usds/case_issues/model/PersistedCase.java
@@ -1,0 +1,18 @@
+package gov.usds.case_issues.model;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public interface PersistedCase extends CaseRequest {
+
+	/** The default time zone for external date formatting */
+	public static final ZoneId GMT = ZoneId.of("Z");
+
+	/** The date that this case was first uploaded (may or may not be the effective date
+	 * of the first upload containing it). */
+	ZonedDateTime getCaseInitialUploadDate();
+
+	/** The date that this case was most recently updated (may or may not be the effective
+	 * date of the upload that changed it. */
+	ZonedDateTime getCaseDataModifiedDate();
+}

--- a/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
@@ -46,10 +46,6 @@ public class DelegatingFilterableCaseSummary implements CaseSummary {
 		return ZonedDateTime.ofInstant(_root.getCreatedAt().toInstant(), GMT);
 	}
 	@Override
-	public boolean isPreviouslySnoozed() {
-		return false;
-	}
-	@Override
 	public CaseSnoozeSummary getSnoozeInformation() {
 		return new DelegatingSnoozeSummary();
 	}

--- a/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
@@ -38,6 +38,14 @@ public class DelegatingFilterableCaseSummary implements CaseSummary {
 		return _root.getExtraData();
 	}
 	@Override
+	public ZonedDateTime getCaseDataModifiedDate() {
+		return ZonedDateTime.ofInstant(_root.getUpdatedAt().toInstant(), GMT);
+	}
+	@Override
+	public ZonedDateTime getCaseInitialUploadDate() {
+		return ZonedDateTime.ofInstant(_root.getCreatedAt().toInstant(), GMT);
+	}
+	@Override
 	public boolean isPreviouslySnoozed() {
 		return false;
 	}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -127,7 +127,8 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		;
 		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
 			.andExpect(status().isOk())
-			.andExpect(content().json("[{'receiptNumber': 'FFFF1111', 'previouslySnoozed': false}]", false))
+			.andExpect(content().json("[{'receiptNumber': 'FFFF1111'}]", false))
+			.andExpect(jsonPath("$.snoozeInformation").doesNotExist())
 		;
 		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
 			.andExpect(status().isOk())

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -129,7 +129,6 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
 			.andExpect(status().isOk())
 			.andExpect(content().json("[{'receiptNumber': 'FFFF1111'}]", false))
-			.andExpect(jsonPath("$.snoozeInformation").doesNotExist())
 			.andExpect(jsonPath("$[0].snoozeInformation").value(Matchers.nullValue()))
 		;
 		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))


### PR DESCRIPTION
Updated the CaseSummary and CaseDetails objects with access to the case creation date and updated date (this will work fine as a proxy for when things actually happened until/unless we use backdated uploads).

Also deleted the `isPreviouslySnoozed` flag, which had apparently been broken but also not used in the UI for the last several iterations.