### PR TITLE
Made case list return null instead of invalid case snooze information.

### DIFF
--- a/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
+++ b/src/main/java/gov/usds/case_issues/services/model/DelegatingFilterableCaseSummary.java
@@ -17,6 +17,7 @@ public class DelegatingFilterableCaseSummary implements CaseSummary {
 
 	private FilterableCase _root;
 	private List<AttachmentSummary> _attachments;
+	private CaseSnoozeSummary _snooze;
 
 	public DelegatingFilterableCaseSummary(FilterableCase r, List<AttachmentSummary> attachments) {
 		_root = r;
@@ -24,7 +25,11 @@ public class DelegatingFilterableCaseSummary implements CaseSummary {
 		if (attachments == null) {
 			_attachments = Collections.emptyList();
 		}
+		if (_root.getSnoozeStart() != null) {
+			_snooze = new DelegatingSnoozeSummary();
+		}
 	}
+
 	@Override
 	public String getReceiptNumber() {
 		return _root.getReceiptNumber();
@@ -43,7 +48,7 @@ public class DelegatingFilterableCaseSummary implements CaseSummary {
 	}
 	@Override
 	public CaseSnoozeSummary getSnoozeInformation() {
-		return new DelegatingSnoozeSummary();
+		return _snooze;
 	}
 	@Override
 	public List<AttachmentSummary> getNotes() {

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -128,10 +129,12 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
 			.andExpect(status().isOk())
 			.andExpect(content().json("[{'receiptNumber': 'FFFF1111', 'previouslySnoozed': false}]", false))
+			.andExpect(jsonPath("$[0].snoozeInformation").value(Matchers.nullValue()))
 		;
 		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
 			.andExpect(status().isOk())
 			.andExpect(content().json("[{'receiptNumber': 'FFFF1112', 'snoozeInformation': {'snoozeReason': 'DONOTCARE'}}]", false))
+			.andExpect(jsonPath("$[0].snoozeInformation").isMap())
 		;
 	}
 


### PR DESCRIPTION
Only create a wrapper CaseSnoozeSummary object if there is something to wrap. Added tests to enforce this behavior.