### PR TITLE
Configure additional HTTP port

### DIFF
--- a/src/main/java/gov/usds/case_issues/config/WebConfig.java
+++ b/src/main/java/gov/usds/case_issues/config/WebConfig.java
@@ -43,8 +43,11 @@ public class WebConfig implements WebMvcConfigurer {
 
 	private static final Logger LOG = LoggerFactory.getLogger(WebConfig.class);
 
-	@Autowired
 	private WebConfigurationProperties _customProperties;
+
+	public WebConfig(@Autowired WebConfigurationProperties webProperties) {
+		_customProperties = webProperties;
+	}
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
@@ -112,6 +115,11 @@ public class WebConfig implements WebMvcConfigurer {
 	@ConditionalOnProperty("web-customization.additional-http-port")
 	public WebServerFactoryCustomizer<TomcatServletWebServerFactory> getServerCustomizer() {
 		int port = _customProperties.getAdditionalHttpPort();
+		if (port <= 0) {
+			throw new IllegalArgumentException(
+				String.format("Configured additional HTTP port (%d) is not valid", port)
+			);
+		}
 		LOG.info("Configuring additional HTTP listener on port {}", port);
 		return f -> {
 			Connector conn = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);

--- a/src/main/java/gov/usds/case_issues/config/WebConfigurationProperties.java
+++ b/src/main/java/gov/usds/case_issues/config/WebConfigurationProperties.java
@@ -20,6 +20,7 @@ public class WebConfigurationProperties {
 	private String[] _corsOrigins;
 	private List<UserDefinition> _users;
 	private Map<String, DataFormatSpec> _dataFormats = new HashMap<>();
+	private int additionalHttpPort;
 
 	public void setCorsOrigins(String[] origins) {
 		_corsOrigins = origins;
@@ -43,6 +44,14 @@ public class WebConfigurationProperties {
 
 	public void setDataFormats(Map<String, DataFormatSpec> dataFormats) {
 		this._dataFormats = dataFormats;
+	}
+
+	public int getAdditionalHttpPort() {
+		return additionalHttpPort;
+	}
+
+	public void setAdditionalHttpPort(int additionalHttpPort) {
+		this.additionalHttpPort = additionalHttpPort;
 	}
 
 	public static class UserDefinition {

--- a/src/main/resources/application-autotest.yml
+++ b/src/main/resources/application-autotest.yml
@@ -53,6 +53,8 @@ bind-testing:
         creation-date-key: "whenever"
       doo:
         creation-date-format: "EEE MMM dd yyyy" # Wed May 7 2031
+  web-conf-e:
+    additional-http-port: 23
   oauth-conf-a:
     name-path:
       - yabba

--- a/src/test/java/gov/usds/case_issues/config/WebConfigTest.java
+++ b/src/test/java/gov/usds/case_issues/config/WebConfigTest.java
@@ -1,0 +1,45 @@
+package gov.usds.case_issues.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+
+import org.apache.catalina.connector.Connector;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+
+import gov.usds.case_issues.test_util.MockConfig;
+
+public class WebConfigTest {
+
+	private WebConfigurationProperties _wrappedProperties = new MockConfig().getMockProperties();
+	private WebConfig _config = new WebConfig(_wrappedProperties);
+
+	@Test
+	@SuppressWarnings("checkstyle:MagicNumber")
+	public void getServerCustomizer_validPort_ok() {
+		int validPort = 123;
+		Mockito.when(_wrappedProperties.getAdditionalHttpPort()).thenReturn(validPort);
+		WebServerFactoryCustomizer<TomcatServletWebServerFactory> c = _config.getServerCustomizer();
+		TomcatServletWebServerFactory factory = Mockito.mock(TomcatServletWebServerFactory.class);
+		c.customize(factory);
+		ArgumentCaptor<Connector> arg = ArgumentCaptor.forClass(Connector.class);
+		Mockito.verify(factory, atLeastOnce()).addAdditionalTomcatConnectors(arg.capture());
+		assertEquals(validPort, arg.getValue().getPort());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void getServerCustomizer_zeroPort_exception() {
+		Mockito.when(_wrappedProperties.getAdditionalHttpPort()).thenReturn(0);
+		_config.getServerCustomizer();
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void getServerCustomizer_negativePort_exception() {
+		Mockito.when(_wrappedProperties.getAdditionalHttpPort()).thenReturn(-1);
+		_config.getServerCustomizer();
+	}
+
+}

--- a/src/test/java/gov/usds/case_issues/config/WebConfigurationPropertiesTest.java
+++ b/src/test/java/gov/usds/case_issues/config/WebConfigurationPropertiesTest.java
@@ -24,6 +24,7 @@ import gov.usds.case_issues.authorization.CaseIssuePermission;
 import gov.usds.case_issues.config.WebConfigurationProperties.UserDefinition;
 import gov.usds.case_issues.test_util.CaseIssueApiTestBase;
 
+@SuppressWarnings("checkstyle:MagicNumber")
 public class WebConfigurationPropertiesTest extends CaseIssueApiTestBase {
 
 	@Autowired
@@ -77,7 +78,6 @@ public class WebConfigurationPropertiesTest extends CaseIssueApiTestBase {
 		assertEquals(0, bound.get().getDataFormats().size());
 	}
 	@Test
-	@SuppressWarnings("checkstyle:MagicNumber")
 	public void bindProperties_simpleDataFormats_found() {
 		BindResult<WebConfigurationProperties> bound = bindProperties("bind-testing.web-conf-d");
 		assertTrue(bound.isBound());
@@ -102,7 +102,18 @@ public class WebConfigurationPropertiesTest extends CaseIssueApiTestBase {
 		assertEquals("EEE MMM dd yyyy", foundFormat.getCreationDateFormat());
 		assertFalse(DateTimeFormatter.ISO_DATE_TIME.equals(foundFormat.getCreationDateParser()));
 		assertEquals("creationDate", foundFormat.getCreationDateKey());
+	}
 
+	@Test
+	public void bindProperties_noHttpPort_defaultFound() {
+		WebConfigurationProperties props = bindProperties("bind-testing.web-conf-d").get();
+		assertEquals(0, props.getAdditionalHttpPort());
+	}
+
+	@Test
+	public void bindProperties_validHttpPort_found() {
+		WebConfigurationProperties props = bindProperties("bind-testing.web-conf-e").get();
+		assertEquals(23, props.getAdditionalHttpPort());
 	}
 
 	private static DataFormatSpec getNonNull(Map<String, DataFormatSpec> dataFormats, String key) {


### PR DESCRIPTION
In order to support listening with both http and https (which I promise is a valid use case), add an additional HTTP connector to the embedded Tomcat server.