### PR TITLE
Update jackson-dataebind to patch vulnerabilities.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 //	implementation "io.springfox:springfox-data-rest:${springFoxVersion}"
 
 	// CVE-2020-10673 requires this update, which is not yet available
-	// implementation "com.fasterxml.jackson.core:jackson-databind:2.9.10.4"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.9.10.4"
 
 	implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv"
 

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -7,7 +7,7 @@ ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3
 com.fasterxml.jackson.core:jackson-annotations:2.9.10
 com.fasterxml.jackson.core:jackson-core:2.9.10
-com.fasterxml.jackson.core:jackson-databind:2.9.10.3
+com.fasterxml.jackson.core:jackson-databind:2.9.10.4
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -7,7 +7,7 @@ ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3
 com.fasterxml.jackson.core:jackson-annotations:2.9.10
 com.fasterxml.jackson.core:jackson-core:2.9.10
-com.fasterxml.jackson.core:jackson-databind:2.9.10.3
+com.fasterxml.jackson.core:jackson-databind:2.9.10.4
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10


### PR DESCRIPTION
Many gadget-deserialization vulnerabilities, most but not all of which are
totally irrelevant:

CVE-2020-9546
CVE-2020-9547
CVE-2020-9548
CVE-2020-9548
CVE-2020-10650
CVE-2020-10672
CVE-2020-10673
CVE-2020-10968
CVE-2020-10969
CVE-2020-11113
CVE-2020-11620