### PR TITLE
Fixed dependency locks for recent updates.

### DIFF
--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -7,7 +7,7 @@ ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3
 com.fasterxml.jackson.core:jackson-annotations:2.9.10
 com.fasterxml.jackson.core:jackson-core:2.9.10
-com.fasterxml.jackson.core:jackson-databind:2.9.10.4
+com.fasterxml.jackson.core:jackson-databind:2.9.10.5
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10
@@ -47,9 +47,9 @@ net.minidev:json-smart:2.3
 net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1
 org.apache.logging.log4j:log4j-api:2.11.2
 org.apache.logging.log4j:log4j-to-slf4j:2.11.2
-org.apache.tomcat.embed:tomcat-embed-core:9.0.35
-org.apache.tomcat.embed:tomcat-embed-el:9.0.35
-org.apache.tomcat.embed:tomcat-embed-websocket:9.0.35
+org.apache.tomcat.embed:tomcat-embed-core:9.0.36
+org.apache.tomcat.embed:tomcat-embed-el:9.0.36
+org.apache.tomcat.embed:tomcat-embed-websocket:9.0.36
 org.aspectj:aspectjweaver:1.9.5
 org.atteo:evo-inflector:1.2.2
 org.dom4j:dom4j:2.1.3

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -7,7 +7,7 @@ ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3
 com.fasterxml.jackson.core:jackson-annotations:2.9.10
 com.fasterxml.jackson.core:jackson-core:2.9.10
-com.fasterxml.jackson.core:jackson-databind:2.9.10.4
+com.fasterxml.jackson.core:jackson-databind:2.9.10.5
 com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10
@@ -47,9 +47,9 @@ net.minidev:json-smart:2.3
 net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1
 org.apache.logging.log4j:log4j-api:2.11.2
 org.apache.logging.log4j:log4j-to-slf4j:2.11.2
-org.apache.tomcat.embed:tomcat-embed-core:9.0.35
-org.apache.tomcat.embed:tomcat-embed-el:9.0.35
-org.apache.tomcat.embed:tomcat-embed-websocket:9.0.35
+org.apache.tomcat.embed:tomcat-embed-core:9.0.36
+org.apache.tomcat.embed:tomcat-embed-el:9.0.36
+org.apache.tomcat.embed:tomcat-embed-websocket:9.0.36
 org.aspectj:aspectjweaver:1.9.5
 org.atteo:evo-inflector:1.2.2
 org.dom4j:dom4j:2.1.3


### PR DESCRIPTION
It is entirely unclear why this didn't fail the build previously...