### PR TITLE
Fail uploads better

### DIFF
--- a/src/test/java/gov/usds/case_issues/controllers/ApiTests.java
+++ b/src/test/java/gov/usds/case_issues/controllers/ApiTests.java
@@ -1,0 +1,57 @@
+package gov.usds.case_issues.controllers;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Container for shared HTTP test constants.
+ */
+public final class ApiTests {
+
+	public static class Filters {
+		static final String MAIN = "mainFilter";
+		static final String CREATION_START = "caseCreationRangeBegin";
+		static final String CREATION_END = "caseCreationRangeEnd";
+		static final String SNOOZE_REASON = "snoozeReason";
+	}
+
+	public static final class FilterParams {
+		public static final String STEM = "filter_";
+		public static final String LINK_BY_TYPE = "hasLinkType";
+		public static final String LINK_BY_CONTENT = "hasLink";
+		public static final String TAG_BY_TYPE = "hasTagType";
+		public static final String TAG_BY_CONTENT = "hasTag";
+		public static final String COMMENT_ANY = "hasAnyComment";
+		public static final String COMMENT_CONTENT = "hasComment";
+		public static final String DATA_FIELD = "dataField";
+	}
+
+	public static final String API_PATH = "/api/cases/{caseManagementSystemTag}/{caseTypeTag}/";
+	public static final String ISSUE_UPLOAD_PATH = API_PATH + "{issueTag}";
+	public static final String CSV_CONTENT = "text/csv";
+
+	public static final String VALID_CASE_MGT_SYS = "F1";
+	public static final String VALID_CASE_TYPE = "C1";
+	public static final String VALID_ISSUE_TYPE = "WONKY";
+
+	static MockHttpServletRequestBuilder doGetCases() {
+		return get(API_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE);
+	}
+
+	static MockHttpServletRequestBuilder doSearch(String cmsTag, String ctTag, String queryString) {
+		return get(API_PATH + "search", cmsTag, ctTag).param("query", queryString);
+	}
+
+	public static MockHttpServletRequestBuilder putIssues(String contentType, String effectiveDate) {
+		return putIssues(contentType).param("effectiveDate", effectiveDate);
+	}
+
+	public static MockHttpServletRequestBuilder putIssues(String contentType) {
+		return put(ISSUE_UPLOAD_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE, VALID_ISSUE_TYPE)
+			.contentType(contentType)
+			.with(csrf());
+	}
+}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerFilteringTest.java
@@ -25,7 +25,7 @@ import gov.usds.case_issues.test_util.CaseListFixtureService;
 import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureAttachment;
 import gov.usds.case_issues.test_util.CaseListFixtureService.FixtureCase;
 import gov.usds.case_issues.test_util.CaseListFixtureService.Keywords;
-import gov.usds.case_issues.controllers.HitlistApiController.FilterParams;
+import gov.usds.case_issues.controllers.ApiTests.FilterParams;
 
 @WithMockUser(authorities="READ_CASES")
 public class HitlistApiControllerFilteringTest extends ControllerTestBase {
@@ -234,7 +234,7 @@ public class HitlistApiControllerFilteringTest extends ControllerTestBase {
 		MultiValueMap<String, String> baseParams = new LinkedMultiValueMap<>();
 		baseParams.put("mainFilter", main.stream().map(CaseSnoozeFilter::name).collect(Collectors.toList()));
 		baseParams.add("size", Integer.toString(pageSize));
-		MockHttpServletRequestBuilder req = get(HitlistApiControllerTest.API_PATH, CaseListFixtureService.SYSTEM, CaseListFixtureService.CASE_TYPE)
+		MockHttpServletRequestBuilder req = get(ApiTests.API_PATH, CaseListFixtureService.SYSTEM, CaseListFixtureService.CASE_TYPE)
 			.params(baseParams)
 			.params(additional)
 			;

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerIntegrationTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerIntegrationTest.java
@@ -1,0 +1,374 @@
+package gov.usds.case_issues.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static gov.usds.case_issues.controllers.ApiTests.doSearch;
+import static gov.usds.case_issues.controllers.ApiTests.doGetCases;
+import static gov.usds.case_issues.controllers.ApiTests.putIssues;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import gov.usds.case_issues.db.model.CaseIssueUpload;
+import gov.usds.case_issues.db.model.CaseManagementSystem;
+import gov.usds.case_issues.db.model.CaseType;
+import gov.usds.case_issues.db.model.TroubleCase;
+import gov.usds.case_issues.db.model.UploadStatus;
+import gov.usds.case_issues.db.model.projections.CaseIssueSummary;
+import gov.usds.case_issues.model.CaseDetails;
+import gov.usds.case_issues.services.CaseDetailsService;
+import gov.usds.case_issues.services.UploadStatusService;
+
+/**
+ * Tests of the Hitlist API behavior that include actual database calls.
+ */
+@WithMockUser(username = "default_hitlist_user", authorities = "READ_CASES")
+@SuppressWarnings("checkstyle:MagicNumber")
+public class HitlistApiControllerIntegrationTest extends ControllerTestBase {
+
+	private static final String CSV_HEADER_SHORT = "receiptNumber,creationDate,channelType\n";
+
+	private static final String DATE_STAMP_2018 = "2018-01-01T12:00:00Z";
+	private static final String DATE_STAMP_2019 = "2019-01-01T12:00:00Z";
+	private static final String VALID_ISSUE_TYPE = ApiTests.VALID_ISSUE_TYPE;
+	private static final String VALID_CASE_TYPE = ApiTests.VALID_CASE_TYPE;
+	private static final String VALID_CASE_MGT_SYS = ApiTests.VALID_CASE_MGT_SYS;
+	private static final String CASE_TYPE_NOPE = "Case Type 'NOPE' was not found";
+	private static final String CASE_MANAGEMENT_SYSTEM_NOPE = "Case Management System 'NOPE' was not found";
+
+	private CaseManagementSystem _system;
+	private CaseType _type;
+
+	@Autowired
+	private UploadStatusService _uploadService;
+	@Autowired
+	private CaseDetailsService _detailsService;
+	
+	@Before
+	public void resetDb() {
+		truncateDb();
+		_system = _dataService.ensureCaseManagementSystemInitialized(VALID_CASE_MGT_SYS, "Fake 1", "Fakest");
+		_type = _dataService.ensureCaseTypeInitialized(VALID_CASE_TYPE, "Case type 1", "");
+	}
+
+	@Test
+	public void invalidPath_correctErrorMessages() throws Exception {
+		_mvc.perform(getActive("NOPE", VALID_CASE_TYPE))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
+		;
+		_mvc.perform(getSnoozed("NOPE", VALID_CASE_TYPE))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
+		;
+		_mvc.perform(getSummary("NOPE", VALID_CASE_TYPE))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
+		;
+		_mvc.perform(getActive(VALID_CASE_MGT_SYS, "NOPE"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
+		;
+		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, "NOPE"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
+		;
+		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, "NOPE"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
+		;
+	}
+
+	@Test
+	public void validPath_noData_emptyResponses() throws Exception {
+		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.NEVER_SNOOZED").doesNotExist())
+			.andExpect(jsonPath("$.CURRENTLY_SNOOZED").doesNotExist())
+			.andExpect(jsonPath("$.PREVIOUSLY_SNOOZED").doesNotExist())
+		;
+	}
+
+	@Test
+	public void getActive_withData_correctResponse() throws Exception {
+		initCaseData();
+		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.NEVER_SNOOZED").value("1"))
+			.andExpect(jsonPath("$.CURRENTLY_SNOOZED").value("1"))
+		;
+		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[{'receiptNumber': 'FFFF1111'}]", false))
+			.andExpect(jsonPath("$[0].snoozeInformation").value(Matchers.nullValue()))
+		;
+		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[{'receiptNumber': 'FFFF1112', 'snoozeInformation': {'snoozeReason': 'DONOTCARE'}}]", false))
+			.andExpect(jsonPath("$[0].snoozeInformation").isMap())
+		;
+	}
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putJson_emptyList_accepted() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE)
+			.content("[]");
+		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(0, 0, 0);
+	}
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putCsv_emptyList_accepted() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = putIssues(ApiTests.CSV_CONTENT)
+			.content("header1,header2\n");
+		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(0, 0, 0);
+	}
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putCsv_singleCase_accepted() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = putIssues(ApiTests.CSV_CONTENT)
+			.content(
+				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
+				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
+			);
+		perform(jsonPut).andExpect(status().isAccepted());
+		checkUploadRecord(1, 1, 0);
+	}
+
+
+	@Test
+	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
+	public void putCsv_backDatedIssues_correctDateUsed() throws Exception {
+		String receiptNumber = "FKE27182818";
+		String effectiveDate = "2017-05-15T20:00:00Z";
+		MockHttpServletRequestBuilder issuePut = putIssues(ApiTests.CSV_CONTENT, effectiveDate)
+			.content(CSV_HEADER_SHORT + receiptNumber + ",2001-08-29T00:00:00-04:00,Pay Per View\n");
+		perform(issuePut).andExpect(status().isAccepted());
+		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
+		assertDateEquals("CSV put effective date", effectiveDate, lastUpload.getEffectiveDate());
+		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
+		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
+		assertTrue("Issue exists", optIssue.isPresent());
+		assertEquals(lastUpload.getEffectiveDate(), optIssue.get().getIssueCreated());
+	}
+
+	@Test
+	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
+	public void putCsv_backDatedIssuesClosed_issueDatesCorrected() throws Exception {
+		String receiptNumber = "FKE27182818";
+		String startDateString = "2010-05-15T20:00:00Z";
+		MockHttpServletRequestBuilder issuePut = putIssues(ApiTests.CSV_CONTENT, startDateString)
+			.content(CSV_HEADER_SHORT + receiptNumber + ",1978-08-29T00:00:00-04:00,Broadcast\n");
+		perform(issuePut).andExpect(status().isAccepted());
+		String endDateString = "2011-04-30T20:00:00Z";
+		issuePut = putIssues(ApiTests.CSV_CONTENT, endDateString)
+			.content(CSV_HEADER_SHORT);
+		perform(issuePut).andExpect(status().isAccepted());
+		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
+		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
+		assertTrue("Issue exists", optIssue.isPresent());
+		assertDateEquals("issue creation backdate", startDateString, optIssue.get().getIssueCreated());
+		assertDateEquals("issue closure backdate", endDateString, optIssue.get().getIssueClosed());
+	}
+
+	@Test
+	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
+	public void putCsv_backDatedIssuesOutOfOrder_conflict() throws Exception {
+		MockHttpServletRequestBuilder issuePut = putIssues(ApiTests.CSV_CONTENT, "2015-05-15T20:00:00Z")
+			.content(CSV_HEADER_SHORT);
+		perform(issuePut).andExpect(status().isAccepted());
+		issuePut = putIssues(ApiTests.CSV_CONTENT, "2010-05-15T20:00:00Z")
+			.content(CSV_HEADER_SHORT);
+		perform(issuePut).andExpect(status().isConflict());
+	}
+
+	@Test
+	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
+	public void putJson_backDatedIssues_correctDateUsed() throws Exception {
+		JSONObject requestCase = new JSONObject();
+		String receiptNumber = "FKE31415926";
+		String effectiveDate = "2019-12-31T20:00:00Z";
+		requestCase.put("receiptNumber", receiptNumber);
+		requestCase.put("creationDate", "2001-08-29T00:00:00-04:00");
+		requestCase.put("channelType", "Pay Per View");
+		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, effectiveDate)
+				.content("[" + requestCase.toString() + "]");
+		perform(jsonPut).andExpect(status().isAccepted());
+		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
+		assertDateEquals("back-dated upload date", effectiveDate, lastUpload.getEffectiveDate());
+		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
+		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
+		assertTrue("Issue exists", optIssue.isPresent());
+		assertEquals(lastUpload.getEffectiveDate(), optIssue.get().getIssueCreated());
+	}
+
+	@Test
+	public void getSummary_dataNeverAdded_noLastActive() throws Exception {
+		initCaseData();
+		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.lastUpdated").doesNotExist());
+	}
+
+
+	@Test
+	@WithMockUser(authorities = {"READ_CASES", "UPDATE_ISSUES"})
+	public void getSummary_emptyCasesAdded_lastActivePresent() throws Exception {
+		initCaseData();
+		perform(put(ApiTests.API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
+			.contentType(ApiTests.CSV_CONTENT)
+			.with(csrf())
+			.content(
+				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
+				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
+		)).andExpect(status().isAccepted());
+
+		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.lastUpdated").isString());
+	}
+
+	@Test
+	public void search_noCases_emptyResult() throws Exception {
+		perform(doSearch(VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "abcde"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true));
+	}
+
+	@Test
+	public void getCases_smokeTest_emptyResponses() throws Exception {
+		perform(doGetCases().param(ApiTests.Filters.MAIN, "ACTIVE"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "ACTIVE")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "ACTIVE")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018)
+				.param(ApiTests.Filters.CREATION_END, DATE_STAMP_2019))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases().param(ApiTests.Filters.MAIN, "SNOOZED"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "SNOOZED")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "SNOOZED")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018)
+				.param(ApiTests.Filters.CREATION_END, DATE_STAMP_2019))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "SNOOZED")
+				.param(ApiTests.Filters.SNOOZE_REASON, "sleepy"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases().param(ApiTests.Filters.MAIN, "ALARMED"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "ALARMED")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+		perform(doGetCases()
+				.param(ApiTests.Filters.MAIN, "ALARMED")
+				.param(ApiTests.Filters.CREATION_START, DATE_STAMP_2018)
+				.param(ApiTests.Filters.CREATION_END, DATE_STAMP_2019))
+			.andExpect(status().isOk())
+			.andExpect(content().json("[]", true))
+		;
+	}
+
+	/**
+	 * Create some data on our default case type!
+	 *
+	 * 1 case that has 1 issue and is currently active
+	 * 1 case that has 1 issue and is currently snoozed
+	 */
+	private void initCaseData() {
+		ZonedDateTime thatWasThen = ZonedDateTime.now().minusMonths(1);
+		TroubleCase case1 = _dataService.initCase(_system, "FFFF1111", _type, thatWasThen);
+		_dataService.initIssue(case1, "FOOBAR", thatWasThen, null);
+		TroubleCase case2 = _dataService.initCase(_system, "FFFF1112", _type, thatWasThen);
+		_dataService.initIssue(case2, "FOOBAR", thatWasThen, null);
+		_dataService.snoozeCase(case2);
+	}
+
+	private void checkUploadRecord(int recordCount, int newIssues, int closedIssues) {
+		Optional<CaseIssueUpload> maybeInfo = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
+		assertTrue(maybeInfo.isPresent());
+		CaseIssueUpload uploadInfo = maybeInfo.get();
+		assertEquals(UploadStatus.SUCCESSFUL, uploadInfo.getUploadStatus());
+		assertEquals(newIssues, uploadInfo.getNewIssueCount().intValue());
+		assertEquals(closedIssues, uploadInfo.getClosedIssueCount().intValue());
+		assertEquals(recordCount, uploadInfo.getUploadedRecordCount());
+	}
+
+	private static MockHttpServletRequestBuilder getActive(String cmsTag, String ctTag) {
+		return get(ApiTests.API_PATH, cmsTag, ctTag).param(ApiTests.Filters.MAIN, "ACTIVE");
+	}
+
+	private static MockHttpServletRequestBuilder getSnoozed(String cmsTag, String ctTag) {
+		return get(ApiTests.API_PATH, cmsTag, ctTag).param(ApiTests.Filters.MAIN, "SNOOZED");
+	}
+
+	private static MockHttpServletRequestBuilder getSummary(String cmsTag, String ctTag) {
+		return get(ApiTests.API_PATH + "summary", cmsTag, ctTag);
+	}
+
+	private static void assertDateEquals(String message, String expected, ZonedDateTime found) {
+		assertDateEquals(message, ZonedDateTime.parse(expected), found);
+	}
+
+	private static void assertDateEquals(String message, ZonedDateTime expected, ZonedDateTime found) {
+		if (!expected.isEqual(found)) {
+			fail(String.format("%s: expected %s, found %s", message, expected, found));
+		}
+	}
+}

--- a/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
+++ b/src/test/java/gov/usds/case_issues/controllers/HitlistApiControllerTest.java
@@ -1,344 +1,70 @@
 package gov.usds.case_issues.controllers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static gov.usds.case_issues.controllers.ApiTests.doGetCases;
+import static gov.usds.case_issues.controllers.ApiTests.doSearch;
+import static gov.usds.case_issues.controllers.ApiTests.putIssues;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.ZonedDateTime;
-import java.util.Optional;
-
-import org.hamcrest.Matchers;
-import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import gov.usds.case_issues.db.model.CaseIssueUpload;
-import gov.usds.case_issues.db.model.CaseManagementSystem;
-import gov.usds.case_issues.db.model.CaseType;
-import gov.usds.case_issues.db.model.TroubleCase;
-import gov.usds.case_issues.db.model.UploadStatus;
-import gov.usds.case_issues.db.model.projections.CaseIssueSummary;
-import gov.usds.case_issues.model.CaseDetails;
-import gov.usds.case_issues.services.CaseDetailsService;
-import gov.usds.case_issues.services.UploadStatusService;
-
+import gov.usds.case_issues.config.DataFormatSpec;
+import gov.usds.case_issues.config.WebConfigurationProperties;
+import gov.usds.case_issues.controllers.ApiTests.Filters;
+import gov.usds.case_issues.services.CaseFilteringService;
+import gov.usds.case_issues.services.CaseListService;
+import gov.usds.case_issues.services.IssueUploadService;
+/**
+ * Tests of the API controller that don't rely on the behavior of the underlying data store.
+ * (Argument validation, security configuration.)
+ */
+@RunWith(SpringRunner.class)
+@WebMvcTest(HitlistApiController.class)
 @WithMockUser(username = "default_hitlist_user", authorities = "READ_CASES")
-@SuppressWarnings("checkstyle:MagicNumber")
-public class HitlistApiControllerTest extends ControllerTestBase {
+public class HitlistApiControllerTest {
 
-	private static final String CSV_HEADER_SHORT = "receiptNumber,creationDate,channelType\n";
-	private static final String CSV_CONTENT = "text/csv";
-	private static final String NO_OP = "non-empty request body";
-
+	private static final String NO_OP = "this request intentionally left blank";
 	private static final String DATE_STAMP_2018 = "2018-01-01T12:00:00Z";
 	private static final String DATE_STAMP_2019 = "2019-01-01T12:00:00Z";
-	private static final String VALID_ISSUE_TYPE = "WONKY";
-	private static final String VALID_CASE_TYPE = "C1";
-	private static final String VALID_CASE_MGT_SYS = "F1";
-	protected static final String API_PATH = "/api/cases/{caseManagementSystemTag}/{caseTypeTag}/";
-	private static final String ISSUE_UPLOAD_PATH = API_PATH + "{issueTag}";
-	private static final String CASE_TYPE_NOPE = "Case Type 'NOPE' was not found";
-	private static final String CASE_MANAGEMENT_SYSTEM_NOPE = "Case Management System 'NOPE' was not found";
 
-	private static class Filters {
-		private static final String MAIN = "mainFilter";
-		private static final String CREATION_START = "caseCreationRangeBegin";
-		private static final String CREATION_END = "caseCreationRangeEnd";
-		private static final String SNOOZE_REASON = "snoozeReason";
-	}
-
-	private CaseManagementSystem _system;
-	private CaseType _type;
+	@MockBean
+	private IssueUploadService _uploadService;
+	@MockBean
+	private CaseListService _listService;
+	@MockBean
+	private CaseFilteringService _filterService;
+	@MockBean
+	private WebConfigurationProperties _properties;
 
 	@Autowired
-	private UploadStatusService _uploadService;
-	@Autowired
-	private CaseDetailsService _detailsService;
-
-	@Before
-	public void resetDb() {
-		truncateDb();
-		_system = _dataService.ensureCaseManagementSystemInitialized(VALID_CASE_MGT_SYS, "Fake 1", "Fakest");
-		_type = _dataService.ensureCaseTypeInitialized(VALID_CASE_TYPE, "Case type 1", "");
-	}
-
-	@Test
-	public void invalidPath_correctErrorMessages() throws Exception {
-		_mvc.perform(getActive("NOPE", VALID_CASE_TYPE))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
-		;
-		_mvc.perform(getSnoozed("NOPE", VALID_CASE_TYPE))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
-		;
-		_mvc.perform(getSummary("NOPE", VALID_CASE_TYPE))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_MANAGEMENT_SYSTEM_NOPE))
-		;
-		_mvc.perform(getActive(VALID_CASE_MGT_SYS, "NOPE"))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
-		;
-		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, "NOPE"))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
-		;
-		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, "NOPE"))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("message").value(CASE_TYPE_NOPE))
-		;
-	}
-
-	@Test
-	public void validPath_noData_emptyResponses() throws Exception {
-		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.NEVER_SNOOZED").doesNotExist())
-			.andExpect(jsonPath("$.CURRENTLY_SNOOZED").doesNotExist())
-			.andExpect(jsonPath("$.PREVIOUSLY_SNOOZED").doesNotExist())
-		;
-	}
-
-	@Test
-	public void getActive_withData_correctResponse() throws Exception {
-		initCaseData();
-		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.NEVER_SNOOZED").value("1"))
-			.andExpect(jsonPath("$.CURRENTLY_SNOOZED").value("1"))
-		;
-		_mvc.perform(getActive(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[{'receiptNumber': 'FFFF1111'}]", false))
-			.andExpect(jsonPath("$[0].snoozeInformation").value(Matchers.nullValue()))
-		;
-		_mvc.perform(getSnoozed(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[{'receiptNumber': 'FFFF1112', 'snoozeInformation': {'snoozeReason': 'DONOTCARE'}}]", false))
-			.andExpect(jsonPath("$[0].snoozeInformation").isMap())
-		;
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putJson_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE)
-			.content("[]");
-		perform(jsonPut).andExpect(status().isAccepted());
-		checkUploadRecord(0, 0, 0);
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putJson_emptyListNoCsrf_forbidden() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = put(ISSUE_UPLOAD_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE, VALID_ISSUE_TYPE)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content("[]");
-		perform(jsonPut).andExpect(status().isForbidden());
-		assertEquals("No upload records should exist",
-				0, _uploadService.getUploadHistory(_system, _type).size());
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putCsv_emptyList_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
-			.content("header1,header2\n");
-		perform(jsonPut).andExpect(status().isAccepted());
-		checkUploadRecord(0, 0, 0);
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putCsv_singleCase_accepted() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
-			.content(
-				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
-				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
-			);
-		perform(jsonPut).andExpect(status().isAccepted());
-		checkUploadRecord(1, 1, 0);
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putCsv_invalidCreationDate_badRequest() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(CSV_CONTENT)
-			.content(
-				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
-				"FKE5250608,NOT A DATE,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
-			);
-		perform(jsonPut).andExpect(status().isBadRequest());
-		assertEquals("No upload records should exist",
-			0, _uploadService.getUploadHistory(_system, _type).size());
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putCsv_backDatedWithoutStructureAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
-			.param("effectiveDate", "2019-12-31T20:00:00Z")
-			.content(NO_OP);
-		perform(issuePut).andExpect(status().isForbidden());
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_STRUCTURE")
-	public void putCsv_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT)
-			.param("effectiveDate", "2019-12-31T20:00:00Z")
-			.content(NO_OP);
-		perform(issuePut).andExpect(status().isForbidden());
-	}
-
-	@Test
-	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
-	public void putCsv_backDatedIssues_correctDateUsed() throws Exception {
-		String receiptNumber = "FKE27182818";
-		String effectiveDate = "2017-05-15T20:00:00Z";
-		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT, effectiveDate)
-			.content(CSV_HEADER_SHORT + receiptNumber + ",2001-08-29T00:00:00-04:00,Pay Per View\n");
-		perform(issuePut).andExpect(status().isAccepted());
-		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
-		assertDateEquals("CSV put effective date", effectiveDate, lastUpload.getEffectiveDate());
-		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
-		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
-		assertTrue("Issue exists", optIssue.isPresent());
-		assertEquals(lastUpload.getEffectiveDate(), optIssue.get().getIssueCreated());
-	}
-
-	@Test
-	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
-	public void putCsv_backDatedIssuesClosed_issueDatesCorrected() throws Exception {
-		String receiptNumber = "FKE27182818";
-		String startDateString = "2010-05-15T20:00:00Z";
-		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT, startDateString)
-			.content(CSV_HEADER_SHORT + receiptNumber + ",1978-08-29T00:00:00-04:00,Broadcast\n");
-		perform(issuePut).andExpect(status().isAccepted());
-		String endDateString = "2011-04-30T20:00:00Z";
-		issuePut = putIssues(CSV_CONTENT, endDateString)
-			.content(CSV_HEADER_SHORT);
-		perform(issuePut).andExpect(status().isAccepted());
-		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
-		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
-		assertTrue("Issue exists", optIssue.isPresent());
-		assertDateEquals("issue creation backdate", startDateString, optIssue.get().getIssueCreated());
-		assertDateEquals("issue closure backdate", endDateString, optIssue.get().getIssueClosed());
-	}
-
-	@Test
-	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
-	public void putCsv_backDatedIssuesOutOfOrder_conflict() throws Exception {
-		MockHttpServletRequestBuilder issuePut = putIssues(CSV_CONTENT, "2015-05-15T20:00:00Z")
-			.content(CSV_HEADER_SHORT);
-		perform(issuePut).andExpect(status().isAccepted());
-		issuePut = putIssues(CSV_CONTENT, "2010-05-15T20:00:00Z")
-			.content(CSV_HEADER_SHORT);
-		perform(issuePut).andExpect(status().isConflict());
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_ISSUES")
-	public void putJson_backDatedWithoutStructureAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, "2019-12-31T20:00:00Z")
-				.content("[]");
-		perform(jsonPut).andExpect(status().isForbidden());
-	}
-
-	@Test
-	@WithMockUser(authorities = "UPDATE_STRUCTURE")
-	public void putJson_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
-		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE)
-			.param("effectiveDate", "2019-12-31T20:00:00Z")
-			.content("[]");
-		perform(jsonPut).andExpect(status().isForbidden());
-	}
-
-	@Test
-	@WithMockUser(authorities = {"UPDATE_ISSUES", "UPDATE_STRUCTURE"})
-	public void putJson_backDatedIssues_correctDateUsed() throws Exception {
-		JSONObject requestCase = new JSONObject();
-		String receiptNumber = "FKE31415926";
-		String effectiveDate = "2019-12-31T20:00:00Z";
-		requestCase.put("receiptNumber", receiptNumber);
-		requestCase.put("creationDate", "2001-08-29T00:00:00-04:00");
-		requestCase.put("channelType", "Pay Per View");
-		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, effectiveDate)
-				.content("[" + requestCase.toString() + "]");
-		perform(jsonPut).andExpect(status().isAccepted());
-		CaseIssueUpload lastUpload = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE).get();
-		assertDateEquals("back-dated upload date", effectiveDate, lastUpload.getEffectiveDate());
-		CaseDetails details = _detailsService.findCaseDetails(VALID_CASE_MGT_SYS, receiptNumber);
-		Optional<? extends CaseIssueSummary> optIssue = details.getIssues().stream().findFirst();
-		assertTrue("Issue exists", optIssue.isPresent());
-		assertEquals(lastUpload.getEffectiveDate(), optIssue.get().getIssueCreated());
-	}
-
-	@Test
-	public void getSummary_dataNeverAdded_noLastActive() throws Exception {
-		initCaseData();
-		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.lastUpdated").doesNotExist());
-	}
-
-
-	@Test
-	@WithMockUser(authorities = {"READ_CASES", "UPDATE_ISSUES"})
-	public void getSummary_emptyCasesAdded_lastActivePresent() throws Exception {
-		initCaseData();
-		perform(put(API_PATH + "{issueTag}", VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "WONKY")
-			.contentType(CSV_CONTENT)
-			.with(csrf())
-			.content(
-				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
-				"FKE5250608,2014-08-29T00:00:00-04:00,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
-		)).andExpect(status().isAccepted());
-
-		_mvc.perform(getSummary(VALID_CASE_MGT_SYS, VALID_CASE_TYPE))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.lastUpdated").isString());
-	}
+	private MockMvc _mvc;
 
 	@Test
 	public void search_withoutQueryParam_badRequest() throws Exception {
-		perform(doSearch(VALID_CASE_MGT_SYS, VALID_CASE_TYPE, null))
+		perform(doSearch(ApiTests.VALID_CASE_MGT_SYS, ApiTests.VALID_CASE_TYPE, null))
 			.andExpect(status().isBadRequest())
 			.andExpect(content().string(""));
 	}
 
 	@Test
-	public void search_noCases_emptyResult() throws Exception {
-		perform(doSearch(VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "abcde"))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true));
-	}
-
-	@Test
 	public void search_invalidInput_badRequest() throws Exception {
-		perform(doSearch(VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "ab cde"))
+		perform(doSearch(ApiTests.VALID_CASE_MGT_SYS, ApiTests.VALID_CASE_TYPE, "ab cde"))
 			.andExpect(status().isBadRequest())
 		;
-		perform(doSearch(VALID_CASE_MGT_SYS, VALID_CASE_TYPE, "ab\ncde"))
+		perform(doSearch(ApiTests.VALID_CASE_MGT_SYS, ApiTests.VALID_CASE_TYPE, "ab\ncde"))
 			.andExpect(status().isBadRequest())
 		;
 	}
@@ -401,67 +127,6 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 	}
 
 	@Test
-	public void getCases_smokeTest_emptyResponses() throws Exception {
-		perform(doGetCases().param(Filters.MAIN, "ACTIVE"))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "ACTIVE")
-				.param(Filters.CREATION_START, DATE_STAMP_2018))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "ACTIVE")
-				.param(Filters.CREATION_START, DATE_STAMP_2018)
-				.param(Filters.CREATION_END, DATE_STAMP_2019))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases().param(Filters.MAIN, "SNOOZED"))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "SNOOZED")
-				.param(Filters.CREATION_START, DATE_STAMP_2018))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "SNOOZED")
-				.param(Filters.CREATION_START, DATE_STAMP_2018)
-				.param(Filters.CREATION_END, DATE_STAMP_2019))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "SNOOZED")
-				.param(Filters.SNOOZE_REASON, "sleepy"))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases().param(Filters.MAIN, "ALARMED"))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "ALARMED")
-				.param(Filters.CREATION_START, DATE_STAMP_2018))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-		perform(doGetCases()
-				.param(Filters.MAIN, "ALARMED")
-				.param(Filters.CREATION_START, DATE_STAMP_2018)
-				.param(Filters.CREATION_END, DATE_STAMP_2019))
-			.andExpect(status().isOk())
-			.andExpect(content().json("[]", true))
-		;
-	}
-
-	@Test
 	public void getCases_invalidAdditionalParamNames_badRequest() throws Exception {
 		perform(doGetCases().param(Filters.MAIN, "ALARMED").param("+nope", "1", "2", "3"))
 			.andExpect(status().isBadRequest())
@@ -477,66 +142,71 @@ public class HitlistApiControllerTest extends ControllerTestBase {
 		;
 	}
 
-	/**
-	 * Create some data on our default case type!
-	 *
-	 * 1 case that has 1 issue and is currently active
-	 * 1 case that has 1 issue and is currently snoozed
-	 */
-	private void initCaseData() {
-		ZonedDateTime thatWasThen = ZonedDateTime.now().minusMonths(1);
-		TroubleCase case1 = _dataService.initCase(_system, "FFFF1111", _type, thatWasThen);
-		_dataService.initIssue(case1, "FOOBAR", thatWasThen, null);
-		TroubleCase case2 = _dataService.initCase(_system, "FFFF1112", _type, thatWasThen);
-		_dataService.initIssue(case2, "FOOBAR", thatWasThen, null);
-		_dataService.snoozeCase(case2);
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putJson_emptyListNoCsrf_forbidden() throws Exception {
+		MockHttpServletRequestBuilder jsonPut =
+			put(ApiTests.ISSUE_UPLOAD_PATH, ApiTests.VALID_CASE_MGT_SYS, ApiTests.VALID_CASE_TYPE, ApiTests.VALID_ISSUE_TYPE)
+			.contentType(MediaType.APPLICATION_JSON)
+ 			.content("[]");
+		_mvc.perform(jsonPut).andExpect(status().isForbidden());
+		Mockito.verifyNoMoreInteractions(_listService, _uploadService);
 	}
 
-	private void checkUploadRecord(int recordCount, int newIssues, int closedIssues) {
-		Optional<CaseIssueUpload> maybeInfo = _uploadService.getLastUpload(_system, _type, VALID_ISSUE_TYPE);
-		assertTrue(maybeInfo.isPresent());
-		CaseIssueUpload uploadInfo = maybeInfo.get();
-		assertEquals(UploadStatus.SUCCESSFUL, uploadInfo.getUploadStatus());
-		assertEquals(newIssues, uploadInfo.getNewIssueCount().intValue());
-		assertEquals(closedIssues, uploadInfo.getClosedIssueCount().intValue());
-		assertEquals(recordCount, uploadInfo.getUploadedRecordCount());
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putJson_backDatedWithoutStructureAuthority_forbidden() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, "2019-12-31T20:00:00Z")
+				.content("[]");
+		_mvc.perform(jsonPut).andExpect(status().isForbidden());
 	}
 
-	private static MockHttpServletRequestBuilder doGetCases() {
-		return get(API_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE);
+	@Test
+	@WithMockUser(authorities = "UPDATE_STRUCTURE")
+	public void putJson_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
+		MockHttpServletRequestBuilder jsonPut = putIssues(MediaType.APPLICATION_JSON_VALUE, "2019-12-31T20:00:00Z")
+			.content("[]");
+		_mvc.perform(jsonPut).andExpect(status().isForbidden());
 	}
 
-	private static MockHttpServletRequestBuilder doSearch(String cmsTag, String ctTag, String queryString) {
-		return get(API_PATH + "search", cmsTag, ctTag).param("query", queryString);
-	}
-	private static MockHttpServletRequestBuilder getActive(String cmsTag, String ctTag) {
-		return get(API_PATH, cmsTag, ctTag).param(Filters.MAIN, "ACTIVE");
+
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putCsv_invalidCreationDate_badRequest() throws Exception {
+		Mockito.when(_listService.getUploadFormat(ArgumentMatchers.isNull()))
+			.thenReturn(new DataFormatSpec());
+		MockHttpServletRequestBuilder jsonPut = putIssues(ApiTests.CSV_CONTENT)
+			.content(
+				"receiptNumber,creationDate,caseAge,channelType,caseState,i90SP,caseStatus,applicationReason,caseId,caseSubstatus\n" +
+				"FKE5250608,NOT A DATE,1816,Pigeon,Happy,true,Eschewing Obfuscation,Boredom,43375,Scrutinizing\n"
+			);
+		_mvc.perform(jsonPut).andExpect(status().isBadRequest());
+		Mockito.verifyNoMoreInteractions(_uploadService);
 	}
 
-	private static MockHttpServletRequestBuilder getSnoozed(String cmsTag, String ctTag) {
-		return get(API_PATH, cmsTag, ctTag).param(Filters.MAIN, "SNOOZED");
+	@Test
+	@WithMockUser(authorities = "UPDATE_ISSUES")
+	public void putCsv_backDatedWithoutStructureAuthority_forbidden() throws Exception {
+		MockHttpServletRequestBuilder issuePut = putIssues(ApiTests.CSV_CONTENT)
+			.param("effectiveDate", "2019-12-31T20:00:00Z")
+			.content(NO_OP);
+		_mvc.perform(issuePut).andExpect(status().isForbidden());
 	}
 
-	private static MockHttpServletRequestBuilder getSummary(String cmsTag, String ctTag) {
-		return get(API_PATH + "summary", cmsTag, ctTag);
+	@Test
+	@WithMockUser(authorities = "UPDATE_STRUCTURE")
+	public void putCsv_backDatedWithoutIssuesAuthority_forbidden() throws Exception {
+		MockHttpServletRequestBuilder issuePut = putIssues(ApiTests.CSV_CONTENT)
+			.param("effectiveDate", "2019-12-31T20:00:00Z")
+			.content(NO_OP);
+		_mvc.perform(issuePut).andExpect(status().isForbidden());
 	}
 
-	private static MockHttpServletRequestBuilder putIssues(String contentType, String effectiveDate) {
-		return putIssues(contentType).param("effectiveDate", effectiveDate);
+
+	// inline this eventually probably
+	private ResultActions perform(MockHttpServletRequestBuilder req) throws Exception {
+		return _mvc.perform(req);
 	}
 
-	private static MockHttpServletRequestBuilder putIssues(String contentType) {
-		return put(ISSUE_UPLOAD_PATH, VALID_CASE_MGT_SYS, VALID_CASE_TYPE, VALID_ISSUE_TYPE)
-			.contentType(contentType)
-			.with(csrf());
-	}
-
-	private static void assertDateEquals(String message, String expected, ZonedDateTime found) {
-		assertDateEquals(message, ZonedDateTime.parse(expected), found);
-	}
-	private static void assertDateEquals(String message, ZonedDateTime expected, ZonedDateTime found) {
-		if (!expected.isEqual(found)) {
-			fail(String.format("%s: expected %s, found %s", message, expected, found));
-		}
-	}
 }


### PR DESCRIPTION
Two different error-condition-surfacing changes, with tests:

* detect duplicate records in the upload request body and reject them as Bad Requests
* detect failed uploads and inform the remote client that there was an Internal Server Error

Significant but reasonably straightforward test rearrangement was required to make this all test cleanly.