### PR TITLE
Remove ill-advised container_name keys from docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.2"
 services:
   db:
     image: "postgres"
-    container_name: "case-issues-dev-db"
     ports:
       - "${CASEISSUES_DB_PORT:-5432}:5432"
     volumes:
@@ -18,7 +17,6 @@ services:
     build:
       context: .
     image:  case-issue-api-build
-    container_name: "api"
     command: bootRun
     environment:
       SPRING_PROFILES_ACTIVE: dev,db-dockerized


### PR DESCRIPTION
These appear to provide no non-cosmetic benefit, and screw with us a lot when we try to use the -p option to "docker-compose up".